### PR TITLE
Update uvicorn app path in main.py files

### DIFF
--- a/pizzaz_server_python/main.py
+++ b/pizzaz_server_python/main.py
@@ -324,4 +324,4 @@ except Exception:
 if __name__ == "__main__":
     import uvicorn
 
-    uvicorn.run("pizzaz_server_python.main:app", host="0.0.0.0", port=8000)
+    uvicorn.run("main:app", host="0.0.0.0", port=8000)

--- a/solar-system_server_python/main.py
+++ b/solar-system_server_python/main.py
@@ -310,4 +310,4 @@ except Exception:  # pragma: no cover - middleware is optional
 if __name__ == "__main__":
     import uvicorn
 
-    uvicorn.run("solar-system_server_python.main:app", host="0.0.0.0", port=8000)
+    uvicorn.run("main:app", host="0.0.0.0", port=8000)


### PR DESCRIPTION
Changed the uvicorn.run app path from the full module path to 'main:app' in both pizzaz_server_python and solar-system_server_python main.py files for consistency and improved portability.