### PR TITLE
Remove unused `sse_path` and `message_path` parameters

### DIFF
--- a/pizzaz_server_python/main.py
+++ b/pizzaz_server_python/main.py
@@ -129,8 +129,6 @@ class PizzaInput(BaseModel):
 
 mcp = FastMCP(
     name="pizzaz-python",
-    sse_path="/mcp",
-    message_path="/mcp/messages",
     stateless_http=True,
 )
 

--- a/solar-system_server_python/main.py
+++ b/solar-system_server_python/main.py
@@ -92,8 +92,6 @@ class SolarInput(BaseModel):
 
 mcp = FastMCP(
     name="solar-system-python",
-    sse_path="/mcp",
-    message_path="/mcp/messages",
     stateless_http=True,
 )
 


### PR DESCRIPTION
These parameters are only used by SSE transport, but the app uses `streamable_http_app()`.