### PR TITLE
fix(vite): correct /@fs path and cross-platform relative fallback on Windows (#7)

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -12,10 +12,14 @@ function buildInputs() {
   );
 }
 
-const toFs = (abs: string) => "/@fs" + abs.replace(/\\/g, "/");
+const toFs = (abs: string) => "/@fs/" + abs.replace(/\\/g, "/");
 
-const toServerRoot = (abs: string) =>
-  "./" + path.posix.relative(process.cwd(), abs).replace(/\\/g, "/");
+const toServerRoot = (abs: string) => {
+  const rel = path.relative(process.cwd(), abs).replace(/\\/g, "/");
+  // If it's not really relative (different drive or absolute), fall back to fs URL
+  if (!rel || rel.startsWith("..") || path.isAbsolute(rel)) return toFs(abs);
+  return "./" + rel;
+};
 
 function multiEntryDevEndpoints(options: {
   entries: Record<string, string>;


### PR DESCRIPTION
**Fixes openai/openai-apps-sdk-examples#7**

**Problem** 
On Windows the dev server failed with errors like: Failed to resolve import "/@fsC:/.../src/pizzaz/index.jsx" The helper produced "/@fs" (missing trailing slash) so the path became /@fsC:/... instead of /@fs/C:/...

**Change**
toFs now returns "/@fs/" + normalized absolute path.
toServerRoot uses path.relative (platform aware), normalizes slashes, and falls back to /@fs for non‑clean relatives.

**Testing**
- Windows 11 (Node 20+): pnpm run dev -> all example pages load (pizzaz, pizzaz-albums, pizzaz-carousel, pizzaz-list, solar-system, todo). HMR works for JS & CSS.
- Linux (Ubuntu): dev + build unchanged.

Build `pnpm run build` outputs an identical asset set (only vite.config.mts changed).

**Scope** 
Dev-time path resolution only; no runtime bundle logic impacted.

**Checklist**
-  Repro confirmed on Windows
-  Fix applied and verified
-  No dependency changes
-  Issue referenced