### PR TITLE
feat: add dynamic resource template support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,3 @@ __pycache__/
 *.py[cod]
 *.egg-info/
 .venv/
-

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 This repository showcases example UI components to be used with the Apps SDK, as well as example MCP servers that expose a collection of components as tools.
 It is meant to be used as a starting point and source of inspiration to build your own apps for ChatGPT.
 
-## MCP + Apps SDK overview
+## MCP + Apps SDK Overview
 
 The Model Context Protocol (MCP) is an open specification for connecting large language model clients to external tools, data, and user interfaces. An MCP server exposes tools that a model can call during a conversation and returns results according to the tool contracts. Those results can include extra metadata—such as inline HTML—that the Apps SDK uses to render rich UI components (widgets) alongside assistant messages.
 
@@ -19,7 +19,7 @@ Because the protocol is transport agnostic, you can host the server over Server-
 
 The MCP servers in this demo highlight how each tool can light up widgets by combining structured payloads with `_meta.openai/outputTemplate` metadata returned from the MCP servers.
 
-## Repository structure
+## Repository Structure
 
 - `src/` – Source for each widget example.
 - `assets/` – Generated HTML, JS, and CSS bundles after running the build step.
@@ -52,13 +52,21 @@ The components are bundled into standalone assets that the MCP servers serve as 
 pnpm run build
 ```
 
-This command runs `build-all.mts`, producing versioned `.html`, `.js`, and `.css` files inside `assets/`. Each widget is wrapped with the CSS it needs so you can host the bundles directly or ship them with your own server.
+This command runs `build-all.mts`, producing versioned `.html`, `.js`, and `.css` files inside `assets/`. Each widget is wrapped with the CSS it needs so you can host the bundles directly or ship them with your own server. If the local assets are missing at runtime, the Pizzaz MCP server automatically falls back to the CDN bundles (version `0038`).
 
 To iterate locally, you can also launch the Vite dev server:
 
 ```bash
 pnpm run dev
 ```
+
+The Vite config binds to `http://127.0.0.1:4444` by default. Need another host or port? Pass CLI overrides (for example, to expose on all interfaces at `4000`):
+
+```bash
+pnpm run dev --host 0.0.0.0 --port 4000
+```
+
+If you change the origin, update the MCP server `.env` (`DOMAIN=<new-origin>`) so widgets resolve correctly.
 
 ## Serve the static assets
 
@@ -67,6 +75,14 @@ If you want to preview the generated bundles without the MCP servers, start the 
 ```bash
 pnpm run serve
 ```
+
+This static server also defaults to port `4444`. Override it when needed:
+
+```bash
+pnpm run serve -p 4000
+```
+
+Make sure the MCP server `DOMAIN` matches the port you choose.
 
 The assets are exposed at [`http://localhost:4444`](http://localhost:4444) with CORS enabled so that local tooling (including MCP inspectors) can fetch them.
 
@@ -79,30 +95,65 @@ The repository ships several demo MCP servers that highlight different widget bu
 
 Every tool response includes plain text content, structured JSON, and `_meta.openai/outputTemplate` metadata so the Apps SDK can hydrate the matching widget.
 
+Each MCP server reads `ENVIRONMENT`, `DOMAIN`, and `PORT` from a `.env` file located in its own directory (`pizzaz_server_node/.env`, `pizzaz_server_python/.env`, `solar-system_server_python/.env`). Instead of exporting shell variables, create or update the `.env` file beside the server you're running. For example, inside `pizzaz_server_node/.env`:
+
+```env
+# Development: consume Vite dev assets on http://localhost:5173
+ENVIRONMENT=local
+
+# Production-style: point to the static asset server started with `pnpm run serve`
+# ENVIRONMENT=production
+# DOMAIN=http://localhost:4444
+
+# Port override (defaults to 8000 when omitted)
+# PORT=8123
+```
+
+- Use `ENVIRONMENT=local` while `pnpm run dev` is serving assets so widgets load without hash suffixes.
+- Switch to `ENVIRONMENT=production` and set `DOMAIN` after running `pnpm run build` and `pnpm run serve` to reference the static bundles.
+- Adjust `PORT` if you need the MCP endpoint on something other than `http://localhost:8000/mcp`.
+
 ### Pizzaz Node server
 
 ```bash
 cd pizzaz_server_node
+pnpm install
 pnpm start
 ```
 
 ### Pizzaz Python server
 
 ```bash
+cd pizzaz_server_python
 python -m venv .venv
+# Windows PowerShell
+.\.venv\Scripts\activate
+# macOS/Linux
 source .venv/bin/activate
-pip install -r pizzaz_server_python/requirements.txt
-uvicorn pizzaz_server_python.main:app --port 8000
+pip install -r requirements.txt
+python main.py
 ```
+
+Prefer invoking uvicorn directly? From the repository root you can run `uvicorn pizzaz_server_python.main:app --port 8000` once dependencies are installed.
+
+> Prefer pnpm scripts? After activating the virtual environment, return to the repository root (for example `cd ..`) and run `pnpm start:pizzaz-python`.
 
 ### Solar system Python server
 
 ```bash
+cd solar-system_server_python
 python -m venv .venv
+# Windows PowerShell
+.\.venv\Scripts\activate
+# macOS/Linux
 source .venv/bin/activate
-pip install -r solar-system_server_python/requirements.txt
-uvicorn solar-system_server_python.main:app --port 8000
+pip install -r requirements.txt
+python main.py
 ```
+
+Prefer invoking uvicorn directly? From the repository root you can run `uvicorn solar-system_server_python.main:app --port 8000` once dependencies are installed.
+
+> Similarly, once the virtual environment is active, head back to the repository root and run `pnpm start:solar-python` to use the wrapper script.
 
 You can reuse the same virtual environment for all Python servers—install the dependencies once and run whichever entry point you need.
 
@@ -112,15 +163,35 @@ To add these apps to ChatGPT, enable [developer mode](https://platform.openai.co
 
 To add your local server without deploying it, you can use a tool like [ngrok](https://ngrok.com/) to expose your local server to the internet.
 
-For example, once your mcp servers are running, you can run:
+For example, once your MCP servers are running, you can run:
 
 ```bash
 ngrok http 8000
 ```
 
-You will get a public URL that you can use to add your local server to ChatGPT in Settings > Connectors.
+Use the generated URL (for example `https://<custom_endpoint>.ngrok-free.app/mcp`) when configuring ChatGPT. All of the demo servers listen on `http://localhost:8000/mcp` by default; adjust the port in the command above if you override it.
 
-For example: `https://<custom_endpoint>.ngrok-free.app/mcp`
+### Hot-swap modes without reconnecting
+
+You can swap between CDN, static builds, and the Vite dev server without reconfiguring ChatGPT:
+
+1. Change the environment you care about (edit the relevant `.env`, run `pnpm run dev`, or rebuild assets and rerun the MCP server).
+2. In ChatGPT, open **Settings → Apps & Connectors →** select your connected app → **Actions → Refresh app**.
+3. Continue the conversation, no reconnects or page reloads are needed.
+
+When switching modes, avoid disconnecting the connector, deleting it, launching a brand-new tunnel, or refreshing the ChatGPT conversation tab. After you hit **Refresh app**, ChatGPT keeps the existing MCP base URL and simply pulls the latest widget HTML/CSS/JS strategy from your server.
+
+| Mode | What you change | Typical `.env` |
+| --- | --- | --- |
+| CDN (easiest) | Nothing beyond the MCP server | (leave `PORT`, `ENVIRONMENT` & `DOMAIN` unset) |
+| Static serve (inline bundles) | `pnpm run build` (optionally `pnpm run serve` to inspect) | `ENVIRONMENT=production` / `PORT=8000` |
+| Dev (Vite hot reload) | Run `pnpm run dev` and point your MCP server at it | `ENVIRONMENT=local` / `DOMAIN=http://127.0.0.1:4444` / `PORT=8000` |
+
+#### Working inside virtual machines
+
+For the smoothest loop, keep everything inside the same VM: run Vite or the static server, the MCP server, ngrok, and your ChatGPT browser session together so localhost resolves correctly. If your browser lives on the host machine while servers stay in the VM, either tunnel the frontend as well (for example, a second `ngrok http 4444` plus `DOMAIN=<that URL>`), or expose the VM via an HTTPS-accessible IP and point `DOMAIN` there.
+
+Switch modes freely → **Actions → Refresh app** → keep building.
 
 Once you add a connector, you can use it in ChatGPT conversations.
 
@@ -129,7 +200,6 @@ You can add your app to the conversation context by selecting it in the "More" o
 ![more-chatgpt](https://github.com/user-attachments/assets/26852b36-7f9e-4f48-a515-aebd87173399)
 
 You can then invoke tools by asking something related. For example, for the Pizzaz app, you can ask "What are the best pizzas in town?".
-
 
 ## Next steps
 

--- a/build-all.mts
+++ b/build-all.mts
@@ -145,9 +145,11 @@ const outputs = fs
 
 const renamed = [];
 
+const buildSalt = process.env.BUILD_SALT ?? new Date().toISOString();
+
 const h = crypto
   .createHash("sha256")
-  .update(pkg.version, "utf8")
+  .update(`${pkg.version}:${buildSalt}`, "utf8")
   .digest("hex")
   .slice(0, 4);
 
@@ -172,25 +174,47 @@ for (const name of builtNames) {
   const cssPath = path.join(dir, `${name}-${h}.css`);
   const jsPath = path.join(dir, `${name}-${h}.js`);
 
-  const css = fs.existsSync(cssPath)
-    ? fs.readFileSync(cssPath, { encoding: "utf8" })
-    : "";
-  const js = fs.existsSync(jsPath)
-    ? fs.readFileSync(jsPath, { encoding: "utf8" })
-    : "";
+  const cssHref = fs.existsSync(cssPath)
+    ? `/${path.basename(cssPath)}?v=${h}`
+    : undefined;
+  const jsSrc = fs.existsSync(jsPath)
+    ? `/${path.basename(jsPath)}?v=${h}`
+    : undefined;
 
-  const cssBlock = css ? `\n  <style>\n${css}\n  </style>\n` : "";
-  const jsBlock = js ? `\n  <script type="module">\n${js}\n  </script>` : "";
+  const extraScript = name === "pizzaz-video"
+    ? "\n  <script>window.__PIZZAZ_VIDEO_URL__ = \"https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4\";<\\/script>"
+    : "";
 
   const html = [
     "<!doctype html>",
     "<html>",
-    `<head>${cssBlock}</head>`,
+    "<head>",
+    cssHref ? `  <link rel=\"stylesheet\" href=\"${cssHref}\">` : "",
+    "</head>",
     "<body>",
-    `  <div id="${name}-root"></div>${jsBlock}`,
+    `  <div id=\"${name}-root\"></div>`,
+    jsSrc ? `  <script type=\"module\" src=\"${jsSrc}\"></script>` : "",
+    extraScript,
     "</body>",
     "</html>",
-  ].join("\n");
+  ]
+    .filter(Boolean)
+    .join("\n");
+
   fs.writeFileSync(htmlPath, html, { encoding: "utf8" });
   console.log(`${htmlPath} (generated)`);
+
+  const stableHtmlPath = path.join(dir, `${name}.html`);
+  fs.writeFileSync(stableHtmlPath, html, { encoding: "utf8" });
+  console.log(`${stableHtmlPath} (generated)`);
+
+  const cleanUrlDir = path.join(dir, name);
+  fs.mkdirSync(cleanUrlDir, { recursive: true });
+  const cleanUrlIndexPath = path.join(cleanUrlDir, "index.html");
+  const cleanHtml = html
+    .replace(`href="${cssHref ?? ""}"`, cssHref ? `href="${cssHref}"` : "")
+    .replace(`src="${jsSrc ?? ""}"`, jsSrc ? `src="${jsSrc}"` : "");
+
+  fs.writeFileSync(cleanUrlIndexPath, cleanHtml, { encoding: "utf8" });
+  console.log(`${cleanUrlIndexPath} (generated)`);
 }

--- a/package.json
+++ b/package.json
@@ -5,12 +5,15 @@
   "main": "host/main.ts",
   "scripts": {
     "build": "tsx ./build-all.mts",
-    "serve": "serve -s ./assets -p 4444 --cors",
+    "serve": "serve -s ./assets --cors",
     "dev": "vite --config vite.config.mts",
     "tsc": "tsc -b",
     "tsc:app": "tsc -p tsconfig.app.json",
     "tsc:node": "tsc -p tsconfig.node.json",
-    "dev:host": "vite --config vite.host.config.mts"
+    "dev:host": "vite --config vite.host.config.mts",
+    "start:pizzaz-node": "pnpm -C pizzaz_server_node start",
+    "start:pizzaz-python": "node ./scripts/run-python-server.mjs pizzaz_server_python/main.py",
+    "start:solar-python": "node ./scripts/run-python-server.mjs solar-system_server_python/main.py"
   },
   "keywords": [],
   "author": "",

--- a/pizzaz_server_node/.env.example
+++ b/pizzaz_server_node/.env.example
@@ -1,0 +1,4 @@
+## Pizzaz MCP (Node) environment variables
+# ENVIRONMENT=local                           # Optional: 'local' or 'production' (default)
+# DOMAIN=http://localhost:4444                # Override dev/serve origin (leave unset for CDN)
+# PORT=8000                                   # Optional: change server port (default 8000)

--- a/pizzaz_server_node/README.md
+++ b/pizzaz_server_node/README.md
@@ -1,6 +1,6 @@
-# Pizzaz MCP server (Node)
+# Pizzaz MCP Server (Node)
 
-This directory contains a minimal Model Context Protocol (MCP) server implemented with the official TypeScript SDK. The server exposes the full suite of Pizzaz demo widgets so you can experiment with UI-bearing tools in ChatGPT developer mode.
+This directory contains a minimal Model Context Protocol (MCP) server implemented with the official TypeScript SDK. The service exposes the five Pizzaz demo widgets and shares configuration with the rest of the workspace: it reads environment flags from a local `.env` file and automatically falls back to the published CDN bundles when local assets are unavailable.
 
 ## Prerequisites
 
@@ -13,7 +13,7 @@ This directory contains a minimal Model Context Protocol (MCP) server implemente
 pnpm install
 ```
 
-If you prefer npm or yarn, adjust the command accordingly.
+Adjust the command if you prefer npm or yarn.
 
 ## Run the server
 
@@ -21,12 +21,46 @@ If you prefer npm or yarn, adjust the command accordingly.
 pnpm start
 ```
 
-The script bootstraps the server over SSE (Server-Sent Events), which makes it compatible with the MCP Inspector as well as ChatGPT connectors. Once running you can list the tools and invoke any of the pizza experiences.
+This launches an HTTP MCP server on `http://localhost:8000/mcp` with two endpoints:
 
-Each tool responds with:
+- `GET /mcp` provides the SSE stream.
+- `POST /mcp/messages?sessionId=...` accepts follow-up messages for active sessions.
 
-- `content`: a short text confirmation that mirrors the original Pizzaz examples.
-- `structuredContent`: a small JSON payload that echoes the topping argument, demonstrating how to ship data alongside widgets.
-- `_meta.openai/outputTemplate`: metadata that binds the response to the matching Skybridge widget shell.
+Configuration lives in `.env` within this directory (loaded automatically via `dotenv`). Update it before starting the server to control asset origins and ports. A typical file looks like:
 
-Feel free to extend the handlers with real data sources, authentication, and persistence.
+```env
+# Use the Vite dev server started with `pnpm run dev`
+ENVIRONMENT=local
+
+# After `pnpm run build && pnpm run serve`, point to the static bundles
+# ENVIRONMENT=production
+# DOMAIN=http://localhost:4444
+
+# Change the default port (defaults to 8000)
+# PORT=8123
+```
+
+Key behaviors:
+
+- When `ENVIRONMENT=local`, widgets load from the Vite dev server (`pnpm run dev` from the repo root) without hashed filenames.
+- When `ENVIRONMENT=production` and `DOMAIN` is set, widgets are served from your local static server (typically `pnpm run serve`).
+- When `ENVIRONMENT` is omitted entirely—or neither local option provides assets—the server falls back to the CDN bundles (version `0038`).
+
+The script boots the server with an SSE transport, which makes it compatible with the MCP Inspector as well as ChatGPT connectors. Once running you can list the tools and invoke any of the pizza experiences.
+- Each tool emits:
+	- `content`: confirmation text matching the requested action.
+	- `structuredContent`: JSON reflecting the requested topping.
+	- `_meta.openai/outputTemplate`: metadata binding the response to the Skybridge widget.
+
+### Hot-swap reminder
+
+After changing `.env`, rebuilding assets, or toggling between dev/static/CDN, open your ChatGPT connector (**Settings → Apps & Connectors → [your app] → Actions → Refresh app**). That keeps the same MCP URL, avoids new ngrok tunnels, and prompts ChatGPT to fetch the latest widget templates. See the root [README](../README.md#hot-swap-modes-without-reconnecting) for the mode cheat sheet and VM tips.
+
+## Next Steps
+
+Extend these handlers with real data sources, authentication, or localization, and customize the widget configuration under `src/` to align with your application.
+
+See main [README.md](../README.md) for:
+- Testing in ChatGPT
+- Architecture overview
+- Advanced configuration

--- a/pizzaz_server_node/package.json
+++ b/pizzaz_server_node/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^0.5.0",
+    "dotenv": "^16.4.5",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/pizzaz_server_node/src/server.ts
+++ b/pizzaz_server_node/src/server.ts
@@ -1,7 +1,11 @@
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
-import { URL } from "node:url";
+import { readFileSync, existsSync, readdirSync, Dirent } from "node:fs";
+import { resolve } from "node:path";
+import { URL, fileURLToPath } from "node:url";
+import crypto from "node:crypto";
 
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import 'dotenv/config';
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import {
   CallToolRequestSchema,
@@ -19,94 +23,594 @@ import {
   type Tool
 } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
+import pkg from "../../package.json" with { type: "json" };
+import markers from "../../src/pizzaz/markers.json" with { type: "json" };
+
+const CDN_BASE = "https://persistent.oaistatic.com/ecosystem-built-assets";
+const CDN_VERSION = "0038";
+
+function getEnv(key: string): string | undefined {
+  const value = process.env[key];
+  return value === undefined ? undefined : value;
+}
+
+// Environment variables - only these three are supported
+const ENVIRONMENT = (getEnv("ENVIRONMENT") ?? "").trim();
+const DOMAIN = (getEnv("DOMAIN") ?? "").trim() || undefined;
+const PORT = (getEnv("PORT") ?? "").trim() || undefined;
+
+// Determine asset serving strategy based on ENVIRONMENT and DOMAIN
+const environment = ENVIRONMENT.toLowerCase();
+const isLocalEnv = environment === "local" || environment === "dev" || environment === "development";
+const rawDevAssetOrigin = DOMAIN ?? (isLocalEnv ? "http://localhost:4444" : undefined);
+const devAssetOrigin = rawDevAssetOrigin?.replace(/\/$/, "");
+
+// When using the Vite dev server (`pnpm run dev`), assets are served without the hash suffix
+const devAssetUseHash = !isLocalEnv;
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const repoRoot = resolve(__dirname, "../../");
+const assetsDir = resolve(repoRoot, "assets");
+
+function discoverAssetHash(dir: string): string | undefined {
+  let entries: Dirent[];
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException;
+    if (err.code !== "ENOENT") {
+      console.warn(`Failed to scan assets directory for hash: ${err.message}`);
+    }
+    return undefined;
+  }
+
+  for (const entry of entries) {
+    if (!entry.isFile()) continue;
+    const match = entry.name.match(/^[a-z0-9-]+-([0-9a-f]{4})\.(?:js|css|html)$/);
+    if (match) {
+      return match[1];
+    }
+  }
+  return undefined;
+}
+
+const computedAssetHash = crypto
+  .createHash("sha256")
+  .update((pkg as { version: string }).version, "utf8")
+  .digest("hex")
+  .slice(0, 4);
+
+const assetHash = (
+  process.env.ASSET_HASH?.trim().toLowerCase() ||
+  discoverAssetHash(assetsDir) ||
+  computedAssetHash
+).toLowerCase();
+
+// In dev with un-hashed assets, derive a version tag from the process start minute
+const isDevUnhashed = Boolean(devAssetOrigin) && !devAssetUseHash;
+const autoDevVersion = isDevUnhashed
+  ? `dev-${Math.floor(Date.now() / 60_000).toString(36)}`
+  : undefined;
+const templateVersion = (autoDevVersion ?? assetHash).toLowerCase();
+
+// Default pizza video (public-domain fallback that does not expire).
+const DEFAULT_PIZZA_VIDEO_URL =
+  "https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4";
+
+const videoScriptSnippet = `<script>window.__PIZZAZ_VIDEO_URL__ = ${JSON.stringify(DEFAULT_PIZZA_VIDEO_URL)};<\/script>`;
+
+type TemplateParameterDefinition = {
+  name: string;
+  description?: string;
+};
+
+type PizzaPlace = {
+  id: string;
+  name: string;
+  description?: string;
+  city?: string;
+  rating?: number;
+  thumbnail?: string;
+  toppings?: string[];
+  priceRange?: string;
+  menu?: MenuItem[];
+  [key: string]: unknown;
+};
+
+type MenuItem = {
+  id: string;
+  name: string;
+  description?: string;
+  price?: string;
+  toppings?: string[];
+  image?: string;
+};
+
+type DynamicTemplateConfig = {
+  uriTemplateBase: string;
+  description?: string;
+  parameters: TemplateParameterDefinition[];
+  render?: (params: Record<string, string>, context: { baseHtml: string }) => string;
+};
 
 type PizzazWidget = {
   id: string;
   title: string;
   templateUri: string;
+  outputTemplate: string;
   invoking: string;
   invoked: string;
   html: string;
   responseText: string;
+  templateParameters?: TemplateParameterDefinition[];
 };
 
-function widgetMeta(widget: PizzazWidget) {
+type WidgetConfig = {
+  id: string;
+  title: string;
+  templateUriBase: string;
+  invoking: string;
+  invoked: string;
+  responseText: string;
+  assetName: string;
+  dynamicTemplate?: DynamicTemplateConfig;
+};
+
+function devHostedWidgetHtml(assetName: string): string | undefined {
+  if (!devAssetOrigin) {
+    return undefined;
+  }
+
+  // Only serve from the dev origin if a corresponding entry exists under src/
+  // This avoids emitting broken links for widgets that rely on CDN-only assets.
+  const srcDir = resolve(repoRoot, "src", assetName);
+  if (!existsSync(srcDir)) {
+    return undefined;
+  }
+
+  const hashSegment = devAssetUseHash ? `-${assetHash}` : "";
+  const cssHref = `${devAssetOrigin}/${assetName}${hashSegment}.css`;
+  const jsSrc = `${devAssetOrigin}/${assetName}${hashSegment}.js`;
+  const extraScript = assetName === "pizzaz-video" ? videoScriptSnippet : "";
+
+  return `
+<div id="${assetName}-root"></div>
+<link rel="stylesheet" href="${cssHref}">
+<script type="module" src="${jsSrc}"></script>
+${extraScript}
+  `.trim();
+}
+
+function inlineWidgetHtml(assetName: string): string | undefined {
+  const cssPath = resolve(assetsDir, `${assetName}-${assetHash}.css`);
+  const jsPath = resolve(assetsDir, `${assetName}-${assetHash}.js`);
+
+  // If either file is missing, silently skip inlining and allow CDN/dev fallback.
+  if (!existsSync(cssPath) || !existsSync(jsPath)) {
+    return undefined;
+  }
+
+  try {
+    const css = readFileSync(cssPath, "utf8");
+    const js = readFileSync(jsPath, "utf8");
+
+    const extraScript = assetName === "pizzaz-video" ? videoScriptSnippet : "";
+
+    return `
+<div id="${assetName}-root"></div>
+<style>
+${css}
+</style>
+<script type="module">
+${js}
+</script>
+${extraScript}
+    `.trim();
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException;
+    // Only warn on unexpected read errors; ENOENT is already handled above.
+    if (err.code !== "ENOENT") {
+      console.warn(
+        `Failed to inline local assets for ${assetName}: ${err.message}. Falling back to CDN.`,
+      );
+    }
+    return undefined;
+  }
+}
+
+function cdnWidgetHtml(assetName: string): string {
+  const extraScript = assetName === "pizzaz-video" ? videoScriptSnippet : "";
+
+  return `
+<div id="${assetName}-root"></div>
+<link rel="stylesheet" href="${CDN_BASE}/${assetName}-${CDN_VERSION}.css">
+<script type="module" src="${CDN_BASE}/${assetName}-${CDN_VERSION}.js"></script>
+${extraScript}
+  `.trim();
+}
+
+function buildWidgetHtml(assetName: string): string {
+  const devHtml = devHostedWidgetHtml(assetName);
+  if (devHtml) {
+    return devHtml;
+  }
+
+  if (!ENVIRONMENT) {
+    console.info(`No ENVIRONMENT set; falling back to CDN assets for ${assetName}`);
+    return cdnWidgetHtml(assetName);
+  }
+
+  return inlineWidgetHtml(assetName) ?? cdnWidgetHtml(assetName);
+}
+
+const TEMPLATE_PARAM_GLOBAL = "__PIZZAZ_TEMPLATE_PARAMS__";
+
+function appendTemplateParamsScript(baseHtml: string, params: Record<string, string>): string {
+  const keys = Object.keys(params);
+  if (keys.length === 0) {
+    return baseHtml;
+  }
+
+  const serialized = JSON.stringify(params);
+  const paramScript = `<script>window.${TEMPLATE_PARAM_GLOBAL} = ${serialized};<\/script>`;
+  return `${baseHtml}\n${paramScript}`;
+}
+
+function escapeRegexSegment(input: string): string {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+type CompiledUriTemplate = {
+  regex: RegExp;
+  parameterNames: string[];
+};
+
+function compileUriTemplate(uriTemplate: string): CompiledUriTemplate {
+  const parameterNames: string[] = [];
+  const placeholderRegex = /\{([^}]+)\}/g;
+  let lastIndex = 0;
+  let pattern = "";
+  let match: RegExpExecArray | null;
+
+  while ((match = placeholderRegex.exec(uriTemplate)) !== null) {
+    const [placeholder, paramName] = match;
+    pattern += escapeRegexSegment(uriTemplate.slice(lastIndex, match.index));
+    parameterNames.push(paramName);
+    pattern += `(?<${paramName}>[^/?#]+)`;
+    lastIndex = match.index + placeholder.length;
+  }
+
+  pattern += escapeRegexSegment(uriTemplate.slice(lastIndex));
+
   return {
-    "openai/outputTemplate": widget.templateUri,
+    parameterNames,
+    regex: new RegExp(`^${pattern}$`)
+  };
+}
+
+type ResourceTemplateHandler = {
+  widget: PizzazWidget;
+  template: ResourceTemplate;
+  compiled: CompiledUriTemplate;
+  render: (params: Record<string, string>) => string;
+};
+
+function fillUriTemplate(uriTemplate: string, params: Record<string, string>): string {
+  return uriTemplate.replace(/\{([^}]+)\}/g, (_match, name: string) => {
+    const value = params[name];
+    return encodeURIComponent(value ?? "");
+  });
+}
+
+type WidgetMetaOptions = {
+  outputTemplate?: string;
+  includeParameterSchema?: boolean;
+  parameterValues?: Record<string, string>;
+  resolvedUri?: string;
+};
+
+function widgetMeta(widget: PizzazWidget, options: WidgetMetaOptions = {}): Record<string, unknown> {
+  const {
+    outputTemplate = widget.outputTemplate,
+    includeParameterSchema = false,
+    parameterValues,
+    resolvedUri
+  } = options;
+
+  const meta: Record<string, unknown> = {
+    "openai/outputTemplate": outputTemplate,
     "openai/toolInvocation/invoking": widget.invoking,
     "openai/toolInvocation/invoked": widget.invoked,
     "openai/widgetAccessible": true,
     "openai/resultCanProduceWidget": true
-  } as const;
+  };
+
+  if (includeParameterSchema && widget.templateParameters?.length) {
+    meta["openai/outputTemplateSchema"] = Object.fromEntries(
+      widget.templateParameters.map((param) => [
+        param.name,
+        {
+          type: "string",
+          ...(param.description ? { description: param.description } : {})
+        }
+      ])
+    );
+  }
+
+  if (parameterValues && Object.keys(parameterValues).length > 0) {
+    meta["openai/outputTemplateValues"] = parameterValues;
+  }
+
+  if (resolvedUri) {
+    meta["openai/outputTemplateResolved"] = resolvedUri;
+  }
+
+  return meta;
 }
 
-const widgets: PizzazWidget[] = [
+function normalize(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function findTopping(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  return toppingsByNormalized.get(normalize(value));
+}
+
+function parsePrice(value: string | undefined): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const match = value.match(/-?\d+(?:\.\d+)?/);
+  if (!match) {
+    return undefined;
+  }
+  const parsed = Number.parseFloat(match[0]);
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+function computePriceRange(menu: MenuItem[] | undefined): string | undefined {
+  if (!menu || menu.length === 0) {
+    return undefined;
+  }
+
+  const values = menu
+    .map((item) => parsePrice(item.price))
+    .filter((value): value is number => typeof value === "number" && !Number.isNaN(value));
+
+  if (values.length === 0) {
+    return undefined;
+  }
+
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const format = (value: number) => `$${Number.isInteger(value) ? value.toFixed(0) : value.toFixed(2)}`;
+
+  if (Math.abs(min - max) < 0.01) {
+    return format(min);
+  }
+
+  return `${format(min)}–${format(max)}`;
+}
+
+function findPizza(value: string | undefined): MenuItemWithRestaurant | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const normalized = normalize(value);
+
+  const byId = menuItemsById.get(normalized);
+  if (byId) {
+    return byId;
+  }
+
+  const byName = menuItemsByNormalizedName.get(normalized);
+  if (byName) {
+    return byName;
+  }
+
+  return menuItems.find(
+    (item) => normalize(item.name) === normalized || normalize(item.id) === normalized
+  );
+}
+
+const widgetConfigs: WidgetConfig[] = [
   {
     id: "pizza-map",
     title: "Show Pizza Map",
-    templateUri: "ui://widget/pizza-map.html",
+    templateUriBase: "ui://widget/pizza-map.html",
     invoking: "Hand-tossing a map",
     invoked: "Served a fresh map",
-    html: `
-<div id="pizzaz-root"></div>
-<link rel="stylesheet" href="https://persistent.oaistatic.com/ecosystem-built-assets/pizzaz-0038.css">
-<script type="module" src="https://persistent.oaistatic.com/ecosystem-built-assets/pizzaz-0038.js"></script>
-    `.trim(),
-    responseText: "Rendered a pizza map!"
+    responseText: "Rendered a pizza map!",
+    assetName: "pizzaz"
   },
   {
     id: "pizza-carousel",
     title: "Show Pizza Carousel",
-    templateUri: "ui://widget/pizza-carousel.html",
+    templateUriBase: "ui://widget/pizza-carousel.html",
     invoking: "Carousel some spots",
     invoked: "Served a fresh carousel",
-    html: `
-<div id="pizzaz-carousel-root"></div>
-<link rel="stylesheet" href="https://persistent.oaistatic.com/ecosystem-built-assets/pizzaz-carousel-0038.css">
-<script type="module" src="https://persistent.oaistatic.com/ecosystem-built-assets/pizzaz-carousel-0038.js"></script>
-    `.trim(),
-    responseText: "Rendered a pizza carousel!"
+    responseText: "Rendered a pizza carousel!",
+    assetName: "pizzaz-carousel"
   },
   {
     id: "pizza-albums",
     title: "Show Pizza Album",
-    templateUri: "ui://widget/pizza-albums.html",
+    templateUriBase: "ui://widget/pizza-albums.html",
     invoking: "Hand-tossing an album",
     invoked: "Served a fresh album",
-    html: `
-<div id="pizzaz-albums-root"></div>
-<link rel="stylesheet" href="https://persistent.oaistatic.com/ecosystem-built-assets/pizzaz-albums-0038.css">
-<script type="module" src="https://persistent.oaistatic.com/ecosystem-built-assets/pizzaz-albums-0038.js"></script>
-    `.trim(),
-    responseText: "Rendered a pizza album!"
+    responseText: "Rendered a pizza album!",
+    assetName: "pizzaz-albums"
   },
   {
     id: "pizza-list",
     title: "Show Pizza List",
-    templateUri: "ui://widget/pizza-list.html",
+    templateUriBase: "ui://widget/pizza-list.html",
     invoking: "Hand-tossing a list",
     invoked: "Served a fresh list",
-    html: `
-<div id="pizzaz-list-root"></div>
-<link rel="stylesheet" href="https://persistent.oaistatic.com/ecosystem-built-assets/pizzaz-list-0038.css">
-<script type="module" src="https://persistent.oaistatic.com/ecosystem-built-assets/pizzaz-list-0038.js"></script>
-    `.trim(),
-    responseText: "Rendered a pizza list!"
+    responseText: "Rendered a pizza list!",
+    assetName: "pizzaz-list",
+    dynamicTemplate: {
+      uriTemplateBase: "ui://widget/pizza-list/{pizzaTopping}.html",
+      description: "Pizza list widget filtered by topping.",
+      parameters: [
+        {
+          name: "pizzaTopping",
+          description: "Name of the topping to highlight in the list."
+        }
+      ]
+    }
   },
   {
     id: "pizza-video",
     title: "Show Pizza Video",
-    templateUri: "ui://widget/pizza-video.html",
+    templateUriBase: "ui://widget/pizza-video.html",
     invoking: "Hand-tossing a video",
     invoked: "Served a fresh video",
-    html: `
-<div id="pizzaz-video-root"></div>
-<link rel="stylesheet" href="https://persistent.oaistatic.com/ecosystem-built-assets/pizzaz-video-0038.css">
-<script type="module" src="https://persistent.oaistatic.com/ecosystem-built-assets/pizzaz-video-0038.js"></script>
-    `.trim(),
-    responseText: "Rendered a pizza video!"
+    responseText: "Rendered a pizza video!",
+    assetName: "pizzaz-video"
   }
 ];
+
+const versionSuffix = templateVersion ? `?v=${templateVersion}` : "";
+
+const resources: Resource[] = [];
+const resourceTemplates: ResourceTemplate[] = [];
+const resourceTemplateHandlers: ResourceTemplateHandler[] = [];
+
+const restaurants: PizzaPlace[] = ((markers as { places?: PizzaPlace[] }).places ?? []).map((place) => {
+  const toppingSet = new Set<string>();
+
+  (place.toppings ?? [])
+    .map((topping) => topping.trim())
+    .filter(Boolean)
+    .forEach((topping) => toppingSet.add(topping));
+
+  const menu = (place.menu ?? []).map((menuItem) => {
+    const sanitizedToppings = (menuItem.toppings ?? [])
+      .map((topping) => topping.trim())
+      .filter(Boolean);
+    sanitizedToppings.forEach((topping) => toppingSet.add(topping));
+
+    return {
+      ...menuItem,
+      toppings: sanitizedToppings,
+      image: menuItem.image ?? place.thumbnail
+    } satisfies MenuItem;
+  });
+
+  const priceRange = computePriceRange(menu);
+
+  return {
+    ...place,
+    toppings: Array.from(toppingSet),
+    menu,
+    priceRange
+  } satisfies PizzaPlace;
+});
+
+type MenuItemWithRestaurant = MenuItem & { restaurant: PizzaPlace };
+
+const menuItems: MenuItemWithRestaurant[] = restaurants.flatMap((place) =>
+  (place.menu ?? []).map((item) => ({
+    ...item,
+    restaurant: place
+  }))
+);
+
+const restaurantsById = new Map<string, PizzaPlace>();
+const restaurantsByNormalizedName = new Map<string, PizzaPlace>();
+
+restaurants.forEach((place) => {
+  restaurantsById.set(place.id.toLowerCase(), place);
+  restaurantsByNormalizedName.set(place.name.toLowerCase(), place);
+});
+
+const menuItemsById = new Map<string, MenuItemWithRestaurant>();
+const menuItemsByNormalizedName = new Map<string, MenuItemWithRestaurant>();
+
+menuItems.forEach((item) => {
+  menuItemsById.set(item.id.toLowerCase(), item);
+  menuItemsByNormalizedName.set(item.name.toLowerCase(), item);
+});
+
+const allToppings = Array.from(
+  new Set(menuItems.flatMap((item) => item.toppings ?? []))
+).sort((a, b) => a.localeCompare(b, undefined, { sensitivity: "base" }));
+
+const toppingsByNormalized = new Map<string, string>();
+allToppings.forEach((topping) => {
+  toppingsByNormalized.set(topping.toLowerCase(), topping);
+});
+
+const widgets: PizzazWidget[] = widgetConfigs.map((config) => {
+  const templateUri = `${config.templateUriBase}${versionSuffix}`;
+  const outputTemplateBase = config.dynamicTemplate?.uriTemplateBase ?? config.templateUriBase;
+  const outputTemplate = `${outputTemplateBase}${versionSuffix}`;
+  const baseHtml = buildWidgetHtml(config.assetName);
+
+  const widget: PizzazWidget = {
+    id: config.id,
+    title: config.title,
+    templateUri,
+    outputTemplate,
+    invoking: config.invoking,
+    invoked: config.invoked,
+    responseText: config.responseText,
+    html: baseHtml,
+    templateParameters: config.dynamicTemplate?.parameters
+  };
+
+  const resourceDescription = `${config.title} widget markup`;
+
+  resources.push({
+    uri: templateUri,
+    name: config.title,
+    description: resourceDescription,
+    mimeType: "text/html+skybridge",
+    _meta: widgetMeta(widget, { outputTemplate: templateUri })
+  });
+
+  resourceTemplates.push({
+    uriTemplate: templateUri,
+    name: config.title,
+    description: resourceDescription,
+    mimeType: "text/html+skybridge",
+    _meta: widgetMeta(widget, { outputTemplate: templateUri })
+  });
+
+  if (config.dynamicTemplate) {
+    const dynamicUriTemplate = `${config.dynamicTemplate.uriTemplateBase}${versionSuffix}`;
+    const compiled = compileUriTemplate(dynamicUriTemplate);
+    const render = config.dynamicTemplate.render
+      ? (params: Record<string, string>) => config.dynamicTemplate!.render!(params, { baseHtml })
+      : (params: Record<string, string>) => appendTemplateParamsScript(baseHtml, params);
+
+    const templatedResource: ResourceTemplate = {
+      uriTemplate: dynamicUriTemplate,
+      name: config.title,
+      description: config.dynamicTemplate.description ?? `${config.title} widget markup (templated)`,
+      mimeType: "text/html+skybridge",
+      _meta: widgetMeta(widget, {
+        outputTemplate: dynamicUriTemplate,
+        includeParameterSchema: true
+      })
+    };
+
+    resourceTemplates.push(templatedResource);
+    resourceTemplateHandlers.push({
+      widget,
+      template: templatedResource,
+      compiled,
+      render
+    });
+  }
+
+  return widget;
+});
 
 const widgetsById = new Map<string, PizzazWidget>();
 const widgetsByUri = new Map<string, PizzazWidget>();
@@ -124,37 +628,65 @@ const toolInputSchema = {
       description: "Topping to mention when rendering the widget."
     }
   },
-  required: ["pizzaTopping"],
+  required: [],
   additionalProperties: false
 } as const;
 
 const toolInputParser = z.object({
-  pizzaTopping: z.string()
+  pizzaTopping: z.string().optional()
 });
 
-const tools: Tool[] = widgets.map((widget) => ({
+const widgetTools: Tool[] = widgets.map((widget) => ({
   name: widget.id,
   description: widget.title,
   inputSchema: toolInputSchema,
   title: widget.title,
-  _meta: widgetMeta(widget)
+  _meta: widgetMeta(widget, { includeParameterSchema: true })
 }));
 
-const resources: Resource[] = widgets.map((widget) => ({
-  uri: widget.templateUri,
-  name: widget.title,
-  description: `${widget.title} widget markup`,
-  mimeType: "text/html+skybridge",
-  _meta: widgetMeta(widget)
-}));
+const availableToppingsTool: Tool = {
+  name: "list-pizza-toppings",
+  title: "List Available Pizza Toppings",
+  description: "Lists every pizza topping supported by the Pizzaz widgets.",
+  inputSchema: {
+    type: "object",
+    properties: {},
+    additionalProperties: false
+  },
+  _meta: {
+    "openai/widgetAccessible": false,
+    "openai/resultCanProduceWidget": false
+  }
+};
 
-const resourceTemplates: ResourceTemplate[] = widgets.map((widget) => ({
-  uriTemplate: widget.templateUri,
-  name: widget.title,
-  description: `${widget.title} widget markup`,
-  mimeType: "text/html+skybridge",
-  _meta: widgetMeta(widget)
-}));
+const pizzaDetailToolInputSchema = {
+  type: "object",
+  properties: {
+    pizzaName: {
+      type: "string",
+      description: "Name or identifier of the pizza to describe."
+    }
+  },
+  required: ["pizzaName"],
+  additionalProperties: false
+} as const;
+
+const pizzaDetailInputParser = z.object({
+  pizzaName: z.string()
+});
+
+const pizzaDetailTool: Tool = {
+  name: "describe-pizza-toppings",
+  title: "Describe Pizza Toppings",
+  description: "Lists the toppings for a specific pizza from the demo dataset.",
+  inputSchema: pizzaDetailToolInputSchema,
+  _meta: {
+    "openai/widgetAccessible": false,
+    "openai/resultCanProduceWidget": false
+  }
+};
+
+const tools: Tool[] = [...widgetTools, availableToppingsTool, pizzaDetailTool];
 
 function createPizzazServer(): Server {
   const server = new Server(
@@ -177,20 +709,64 @@ function createPizzazServer(): Server {
   server.setRequestHandler(ReadResourceRequestSchema, async (request: ReadResourceRequest) => {
     const widget = widgetsByUri.get(request.params.uri);
 
-    if (!widget) {
-      throw new Error(`Unknown resource: ${request.params.uri}`);
+    if (widget) {
+      return {
+        contents: [
+          {
+            uri: widget.templateUri,
+            mimeType: "text/html+skybridge",
+            text: widget.html,
+            _meta: widgetMeta(widget, {
+              outputTemplate: widget.templateUri,
+              resolvedUri: widget.templateUri
+            })
+          }
+        ]
+      };
     }
 
-    return {
-      contents: [
-        {
-          uri: widget.templateUri,
-          mimeType: "text/html+skybridge",
-          text: widget.html,
-          _meta: widgetMeta(widget)
+    for (const handler of resourceTemplateHandlers) {
+      const match = handler.compiled.regex.exec(request.params.uri);
+      const groups = match?.groups;
+
+      if (!groups) {
+        continue;
+      }
+
+      const params: Record<string, string> = {};
+      handler.compiled.parameterNames.forEach((name) => {
+        const value = groups[name];
+        if (typeof value === "string" && value.length > 0) {
+          let decoded = value;
+          try {
+            decoded = decodeURIComponent(value);
+          } catch (error) {
+            console.warn(`Failed to decode template parameter ${name}: ${(error as Error).message}`);
+          }
+          params[name] = decoded;
         }
-      ]
-    };
+      });
+
+      const html = handler.render(params);
+
+      return {
+        contents: [
+          {
+            uri: request.params.uri,
+            mimeType: "text/html+skybridge",
+            text: html,
+            _meta: widgetMeta(handler.widget, {
+              outputTemplate: handler.template.uriTemplate,
+              includeParameterSchema: true,
+              parameterValues: params,
+              resolvedUri: request.params.uri
+            })
+          }
+        ]
+      };
+    }
+
+    throw new Error(`Unknown resource: ${request.params.uri}`);
   });
 
   server.setRequestHandler(ListResourceTemplatesRequestSchema, async (_request: ListResourceTemplatesRequest) => ({
@@ -202,6 +778,106 @@ function createPizzazServer(): Server {
   }));
 
   server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest) => {
+    if (request.params.name === availableToppingsTool.name) {
+      const toppingsList = allToppings;
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Here are the toppings you can request: ${toppingsList
+              .map((topping) => `“${topping}”`)
+              .join(", ")}.`
+          }
+        ],
+        structuredContent: {
+          availableToppings: toppingsList
+        },
+        _meta: {
+          "openai/widgetAccessible": false,
+          "openai/resultCanProduceWidget": false
+        }
+      };
+    }
+
+    if (request.params.name === pizzaDetailTool.name) {
+      const args = pizzaDetailInputParser.parse(request.params.arguments ?? {});
+      const pizza = findPizza(args.pizzaName);
+
+      if (!pizza) {
+        const suggestions = menuItems
+          .slice(0, 6)
+          .map((item) => `${item.name} (${item.restaurant.name})`)
+          .join(", ");
+        return {
+          content: [
+            {
+              type: "text",
+              text: `I couldn’t find a pizza named “${args.pizzaName}”. Try one of these: ${suggestions}.`
+            }
+          ],
+          structuredContent: {
+            availablePizzas: menuItems.map((item) => ({
+              id: item.id,
+              name: item.name,
+              price: item.price,
+              toppings: item.toppings ?? [],
+              restaurant: {
+                id: item.restaurant.id,
+                name: item.restaurant.name,
+                city: item.restaurant.city,
+                rating: item.restaurant.rating,
+                priceRange: item.restaurant.priceRange
+              }
+            }))
+          },
+          _meta: {
+            "openai/widgetAccessible": false,
+            "openai/resultCanProduceWidget": false
+          }
+        };
+      }
+
+      const { restaurant, ...menuItem } = pizza;
+      const toppings = menuItem.toppings ?? [];
+      const toppingsText = toppings.length
+        ? toppings.map((topping) => `“${topping}”`).join(", ")
+        : "no recorded toppings";
+      const priceFragment = menuItem.price ? ` It costs ${menuItem.price}.` : "";
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `${menuItem.name} from ${restaurant.name} features ${toppingsText}.${priceFragment}`
+          }
+        ],
+        structuredContent: {
+          pizza: {
+            id: menuItem.id,
+            name: menuItem.name,
+            description: menuItem.description,
+            price: menuItem.price,
+            toppings,
+            image: menuItem.image
+          },
+          restaurant: {
+            id: restaurant.id,
+            name: restaurant.name,
+            city: restaurant.city,
+            description: restaurant.description,
+            rating: restaurant.rating,
+            thumbnail: restaurant.thumbnail,
+            priceRange: restaurant.priceRange
+          },
+          toppings
+        },
+        _meta: {
+          "openai/widgetAccessible": false,
+          "openai/resultCanProduceWidget": false
+        }
+      };
+    }
+
     const widget = widgetsById.get(request.params.name);
 
     if (!widget) {
@@ -209,18 +885,43 @@ function createPizzazServer(): Server {
     }
 
     const args = toolInputParser.parse(request.params.arguments ?? {});
+    const rawTopping = args.pizzaTopping?.trim() ?? "";
+    const matchedTopping = findTopping(rawTopping);
+    const hasRecognizedTopping = Boolean(matchedTopping);
+
+    const parameterValues = hasRecognizedTopping && widget.templateParameters?.length
+      ? {
+          pizzaTopping: matchedTopping as string
+        }
+      : undefined;
+
+    const resolvedOutputTemplate = hasRecognizedTopping
+      ? fillUriTemplate(widget.outputTemplate, parameterValues ?? {})
+      : widget.templateUri;
+
+    const metaOutputTemplate = hasRecognizedTopping ? widget.outputTemplate : widget.templateUri;
 
     return {
       content: [
         {
           type: "text",
-          text: widget.responseText
+          text: hasRecognizedTopping
+            ? `${widget.responseText} Filtered by “${matchedTopping}”.`
+            : `${widget.responseText} Showing all pizzas.`
         }
       ],
       structuredContent: {
-        pizzaTopping: args.pizzaTopping
+        pizzaTopping: hasRecognizedTopping ? matchedTopping : null,
+        availableToppings: allToppings,
+        filterApplied: hasRecognizedTopping,
+        requestedTopping: rawTopping || null
       },
-      _meta: widgetMeta(widget)
+      _meta: widgetMeta(widget, {
+        includeParameterSchema: true,
+        parameterValues,
+        resolvedUri: resolvedOutputTemplate,
+        outputTemplate: metaOutputTemplate
+      })
     };
   });
 
@@ -296,7 +997,7 @@ async function handlePostMessage(
   }
 }
 
-const portEnv = Number(process.env.PORT ?? 8000);
+const portEnv = Number(PORT ?? 8000);
 const port = Number.isFinite(portEnv) ? portEnv : 8000;
 
 const httpServer = createServer(async (req: IncomingMessage, res: ServerResponse) => {

--- a/pizzaz_server_python/.env.example
+++ b/pizzaz_server_python/.env.example
@@ -1,0 +1,5 @@
+## Pizzaz MCP (Python) environment variables
+# Note: All variables are optional. With nothing set, the servers default to CDN.
+# ENVIRONMENT=local                           # Optional: 'local' or 'production' (default)
+# DOMAIN=http://localhost:4444                # Override dev/serve origin (leave unset for CDN)
+# PORT=8000                                   # Optional: change server port (default 8000)

--- a/pizzaz_server_python/README.md
+++ b/pizzaz_server_python/README.md
@@ -1,6 +1,6 @@
-# Pizzaz MCP server (Python)
+# Pizzaz MCP Server (Python)
 
-This directory packages a Python implementation of the Pizzaz demo server using the `FastMCP` helper from the official Model Context Protocol SDK. It mirrors the Node example and exposes each pizza widget as both a resource and a tool.
+This directory packages a Python implementation of the Pizzaz demo server using the `FastMCP` helper from the official Model Context Protocol SDK. It mirrors the Node example and exposes each pizza widget as both a resource and a tool while sharing configuration through a local `.env` file and falling back to the published CDN bundles when needed.
 
 ## Prerequisites
 
@@ -10,6 +10,12 @@ This directory packages a Python implementation of the Pizzaz demo server using 
 ## Installation
 
 ```bash
+# Windows
+python -m venv .venv
+.venv\Scripts\activate
+pip install -r requirements.txt
+
+# Unix/Mac
 python -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
@@ -22,7 +28,7 @@ pip install -r requirements.txt
 > other project, run `pip uninstall modelcontextprotocol` before reinstalling
 > the requirements.
 
-## Run the server
+## Run the Server
 
 ```bash
 python main.py
@@ -33,7 +39,34 @@ This boots a FastAPI app with uvicorn on `http://127.0.0.1:8000` (equivalently `
 - `GET /mcp` exposes the SSE stream.
 - `POST /mcp/messages?sessionId=...` accepts follow-up messages for an active session.
 
-Cross-origin requests are allowed so you can drive the server from local tooling or the MCP Inspector. Each tool returns structured content that echoes the requested topping plus metadata that points to the correct Skybridge widget shell, matching the original Pizzaz documentation.
+Cross-origin requests are allowed so you can drive the server from local tooling or the MCP Inspector. The process loads configuration from `.env` in this directory. Update it to control asset origin and port selection, for example:
+
+```env
+# Use the Vite dev server started in the repo root with `pnpm run dev`
+ENVIRONMENT=local
+
+# After `pnpm run build && pnpm run serve`, point to the static bundles
+# ENVIRONMENT=production
+# DOMAIN=http://localhost:4444
+
+# Change the default port (defaults to 8000)
+# PORT=8123
+```
+
+- When `ENVIRONMENT=local`, widgets hydrate from the running Vite dev server without hashed filenames.
+- When `ENVIRONMENT=production` alongside a `DOMAIN`, widgets load from your local static server.
+- When `ENVIRONMENT` is omitted entirely, the server now defaults to the CDN assets (version `0038`) just like the Node implementation.
+- Each tool response includes confirmation text, structured JSON echoing the requested topping, and `_meta.openai/outputTemplate` metadata for the Skybridge widget.
+
+Prefer a cross-platform launcher? After activating the environment you can run:
+
+```bash
+pnpm start:pizzaz-python
+```
+
+## Hot-swap reminder
+
+Whenever you switch the server mode (dev/static/CDN), tweak `.env`, or rebuild assets, refresh your ChatGPT connector instead of deleting it: **Settings → Apps & Connectors → [your app] → Actions → Refresh app**. ChatGPT keeps the same MCP endpoint and reloads widget templates in place. The main [README](../README.md#hot-swap-modes-without-reconnecting) has a concise cheat sheet plus VM guidance.
 
 ## Next steps
 
@@ -42,3 +75,8 @@ Use these handlers as a starting point when wiring in real data, authentication,
 1. Register reusable UI resources that load static HTML bundles.
 2. Associate tools with those widgets via `_meta.openai/outputTemplate`.
 3. Ship structured JSON alongside human-readable confirmation text.
+
+See main [README.md](../README.md) for:
+- Testing in ChatGPT
+- Architecture overview
+- Advanced configuration

--- a/pizzaz_server_python/main.py
+++ b/pizzaz_server_python/main.py
@@ -11,11 +11,108 @@ from __future__ import annotations
 
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import Any, Dict, List
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Pattern, Tuple
+import re
+
+import hashlib
+from dotenv import load_dotenv
+import json
+import logging
+import os
+import time
+from urllib.parse import quote, unquote
 
 import mcp.types as types
 from mcp.server.fastmcp import FastMCP
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+logger = logging.getLogger(__name__)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Load .env from this server directory if present, with OS env taking precedence
+try:
+    load_dotenv(REPO_ROOT / "pizzaz_server_python" / ".env")
+except Exception:
+    pass
+ASSETS_DIR = REPO_ROOT / "assets"
+
+with (REPO_ROOT / "package.json").open("r", encoding="utf-8") as package_file:
+    _package_version = json.load(package_file)["version"]
+
+DEFAULT_ASSET_HASH = hashlib.sha256(_package_version.encode("utf-8")).hexdigest()[:4]
+
+
+def _discover_asset_hash() -> str | None:
+    try:
+        candidates = sorted(
+            ASSETS_DIR.glob("*.js"),
+            key=lambda p: p.stat().st_mtime,
+            reverse=True,
+        )
+    except FileNotFoundError:
+        return None
+    except OSError as exc:  # pragma: no cover
+        logger.warning("Failed to scan assets directory for hash: %s", exc)
+        return None
+
+    pattern = re.compile(r"^[a-z0-9-]+-([0-9a-f]{4})\.js$")
+    for candidate in candidates:
+        match = pattern.match(candidate.name)
+        if match:
+            return match.group(1)
+    return None
+
+
+def _get_env(key: str) -> str | None:
+    return os.environ.get(key)
+
+
+# Environment variables - only these three are supported
+ENVIRONMENT = (_get_env("ENVIRONMENT") or "").strip()
+DOMAIN = (_get_env("DOMAIN") or "").strip() or None
+PORT = (_get_env("PORT") or "").strip() or None
+
+# Internal constants
+CDN_BASE = "https://persistent.oaistatic.com/ecosystem-built-assets"
+CDN_VERSION = "0038"
+
+# Determine asset serving strategy based on ENVIRONMENT and DOMAIN
+_environment = ENVIRONMENT.lower()
+_is_env_local = _environment in {"local", "dev", "development"}
+
+if DOMAIN:
+    _dev_asset_origin = DOMAIN.rstrip("/")
+elif _is_env_local:
+    _dev_asset_origin = "http://localhost:4444"
+else:
+    _dev_asset_origin = None
+
+# When using the Vite dev server (`pnpm run dev`), assets are served without the hash suffix
+_dev_asset_hashed = not _is_env_local
+
+asset_hash_override = (_get_env("ASSET_HASH") or "").strip().lower()
+_asset_hash = asset_hash_override or (_discover_asset_hash() or DEFAULT_ASSET_HASH).lower()
+
+# In dev with un-hashed assets, derive a version tag from the process start minute
+_is_dev_unhashed = bool(_dev_asset_origin) and (not _dev_asset_hashed)
+_auto_dev_version = None
+if _is_dev_unhashed:
+    # Auto-bump once per minute: dev-<base36(minutes since epoch)>
+    _auto_dev_version = f"dev-{int(time.time() // 60):x}"
+
+_template_version = (
+    _auto_dev_version
+    or _asset_hash
+).lower()
+_version_suffix = f"?v={_template_version}" if _template_version else ""
+
+# Default pizza video (public-domain fallback that does not expire).
+DEFAULT_PIZZA_VIDEO_URL = "https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4"
+
+VIDEO_URL_SCRIPT = f"<script>window.__PIZZAZ_VIDEO_URL__ = {json.dumps(DEFAULT_PIZZA_VIDEO_URL)};</script>"
 
 
 @dataclass(frozen=True)
@@ -23,105 +120,542 @@ class PizzazWidget:
     identifier: str
     title: str
     template_uri: str
+    output_template: str
     invoking: str
     invoked: str
-    html: str
+    base_html: str
     response_text: str
+    template_parameters: List[Dict[str, str]]
 
 
-widgets: List[PizzazWidget] = [
-    PizzazWidget(
-        identifier="pizza-map",
-        title="Show Pizza Map",
-        template_uri="ui://widget/pizza-map.html",
-        invoking="Hand-tossing a map",
-        invoked="Served a fresh map",
-        html=(
-            "<div id=\"pizzaz-root\"></div>\n"
-            "<link rel=\"stylesheet\" href=\"https://persistent.oaistatic.com/"
-            "ecosystem-built-assets/pizzaz-0038.css\">\n"
-            "<script type=\"module\" src=\"https://persistent.oaistatic.com/"
-            "ecosystem-built-assets/pizzaz-0038.js\"></script>"
-        ),
-        response_text="Rendered a pizza map!",
-    ),
-    PizzazWidget(
-        identifier="pizza-carousel",
-        title="Show Pizza Carousel",
-        template_uri="ui://widget/pizza-carousel.html",
-        invoking="Carousel some spots",
-        invoked="Served a fresh carousel",
-        html=(
-            "<div id=\"pizzaz-carousel-root\"></div>\n"
-            "<link rel=\"stylesheet\" href=\"https://persistent.oaistatic.com/"
-            "ecosystem-built-assets/pizzaz-carousel-0038.css\">\n"
-            "<script type=\"module\" src=\"https://persistent.oaistatic.com/"
-            "ecosystem-built-assets/pizzaz-carousel-0038.js\"></script>"
-        ),
-        response_text="Rendered a pizza carousel!",
-    ),
-    PizzazWidget(
-        identifier="pizza-albums",
-        title="Show Pizza Album",
-        template_uri="ui://widget/pizza-albums.html",
-        invoking="Hand-tossing an album",
-        invoked="Served a fresh album",
-        html=(
-            "<div id=\"pizzaz-albums-root\"></div>\n"
-            "<link rel=\"stylesheet\" href=\"https://persistent.oaistatic.com/"
-            "ecosystem-built-assets/pizzaz-albums-0038.css\">\n"
-            "<script type=\"module\" src=\"https://persistent.oaistatic.com/"
-            "ecosystem-built-assets/pizzaz-albums-0038.js\"></script>"
-        ),
-        response_text="Rendered a pizza album!",
-    ),
-    PizzazWidget(
-        identifier="pizza-list",
-        title="Show Pizza List",
-        template_uri="ui://widget/pizza-list.html",
-        invoking="Hand-tossing a list",
-        invoked="Served a fresh list",
-        html=(
-            "<div id=\"pizzaz-list-root\"></div>\n"
-            "<link rel=\"stylesheet\" href=\"https://persistent.oaistatic.com/"
-            "ecosystem-built-assets/pizzaz-list-0038.css\">\n"
-            "<script type=\"module\" src=\"https://persistent.oaistatic.com/"
-            "ecosystem-built-assets/pizzaz-list-0038.js\"></script>"
-        ),
-        response_text="Rendered a pizza list!",
-    ),
-    PizzazWidget(
-        identifier="pizza-video",
-        title="Show Pizza Video",
-        template_uri="ui://widget/pizza-video.html",
-        invoking="Hand-tossing a video",
-        invoked="Served a fresh video",
-        html=(
-            "<div id=\"pizzaz-video-root\"></div>\n"
-            "<link rel=\"stylesheet\" href=\"https://persistent.oaistatic.com/"
-            "ecosystem-built-assets/pizzaz-video-0038.css\">\n"
-            "<script type=\"module\" src=\"https://persistent.oaistatic.com/"
-            "ecosystem-built-assets/pizzaz-video-0038.js\"></script>"
-        ),
-        response_text="Rendered a pizza video!",
-    ),
+@dataclass(frozen=True)
+class ResourceTemplateHandler:
+    widget: PizzazWidget
+    uri_template: str
+    pattern: Pattern[str]
+    parameter_names: List[str]
+    render: Callable[[Dict[str, str]], str]
+
+
+def _inline_widget_markup(asset_name: str) -> str | None:
+    css_path = ASSETS_DIR / f"{asset_name}-{_asset_hash}.css"
+    js_path = ASSETS_DIR / f"{asset_name}-{_asset_hash}.js"
+
+    try:
+        css = css_path.read_text(encoding="utf-8")
+        js = js_path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+    except OSError as exc:  # pragma: no cover
+        logger.warning("Failed to load local assets for %s (%s)", asset_name, exc)
+        return None
+
+    extra = VIDEO_URL_SCRIPT if asset_name == "pizzaz-video" else ""
+
+    return (
+        f'<div id="{asset_name}-root"></div>\n'
+        f"<style>\n{css}\n</style>\n"
+        f"<script type=\"module\">\n{js}\n</script>\n"
+        f"{extra}"
+    )
+
+
+def _cdn_widget_markup(asset_name: str) -> str:
+    extra = VIDEO_URL_SCRIPT if asset_name == "pizzaz-video" else ""
+
+    return (
+        f'<div id="{asset_name}-root"></div>\n'
+        f'<link rel="stylesheet" href="{CDN_BASE}/{asset_name}-{CDN_VERSION}.css">\n'
+        f'<script type="module" src="{CDN_BASE}/{asset_name}-{CDN_VERSION}.js"></script>\n'
+        f"{extra}"
+    )
+
+
+def _dev_hosted_widget_markup(asset_name: str) -> str | None:
+    if not _dev_asset_origin:
+        return None
+
+    # Only serve from the dev origin if a corresponding entry exists under src/
+    # This avoids emitting broken links for widgets that rely on CDN-only assets.
+    src_dir = REPO_ROOT / "src" / asset_name
+    if not src_dir.exists():
+        return None
+
+    hash_segment = f"-{_asset_hash}" if _dev_asset_hashed else ""
+    css_href = f"{_dev_asset_origin}/{asset_name}{hash_segment}.css"
+    js_src = f"{_dev_asset_origin}/{asset_name}{hash_segment}.js"
+
+    extra = VIDEO_URL_SCRIPT if asset_name == "pizzaz-video" else ""
+
+    return (
+        f'<div id="{asset_name}-root"></div>\n'
+        f'<link rel="stylesheet" href="{css_href}">\n'
+        f'<script type="module" src="{js_src}"></script>\n'
+        f"{extra}"
+    )
+
+
+def _build_widget_markup(asset_name: str) -> str:
+    dev_markup = _dev_hosted_widget_markup(asset_name)
+    if dev_markup is not None:
+        logger.info("Serving %s from dev asset origin %s", asset_name, _dev_asset_origin)
+        return dev_markup
+
+    if not ENVIRONMENT:
+        logger.info(
+            "No ENVIRONMENT specified; falling back to CDN assets for %s",
+            asset_name,
+        )
+        return _cdn_widget_markup(asset_name)
+
+    inline = _inline_widget_markup(asset_name)
+    if inline is not None:
+        return inline
+
+    logger.info(
+        "Using CDN assets for %s (no matching local assets for hash %s in %s)",
+        asset_name,
+        _asset_hash,
+        ASSETS_DIR,
+    )
+    return _cdn_widget_markup(asset_name)
+
+
+TEMPLATE_PARAM_GLOBAL = "__PIZZAZ_TEMPLATE_PARAMS__"
+
+
+def append_template_params_script(base_html: str, params: Dict[str, str]) -> str:
+    if not params:
+        return base_html
+
+    serialized = json.dumps(params)
+    # Escape the closing tag to avoid early termination when embedded inline
+    script = f"<script>window.{TEMPLATE_PARAM_GLOBAL} = {serialized};<\\/script>"
+    return f"{base_html}\n{script}"
+
+
+def _escape_regex_segment(value: str) -> str:
+    return re.escape(value)
+
+
+def compile_uri_template(uri_template: str) -> tuple[Pattern[str], List[str]]:
+    parameter_names: List[str] = []
+    pattern_parts: List[str] = []
+    last_index = 0
+
+    for match in re.finditer(r"\{([^}]+)\}", uri_template):
+        parameter = match.group(1)
+        pattern_parts.append(_escape_regex_segment(uri_template[last_index:match.start()]))
+        parameter_names.append(parameter)
+        pattern_parts.append(f"(?P<{parameter}>[^/?#]+)")
+        last_index = match.end()
+
+    pattern_parts.append(_escape_regex_segment(uri_template[last_index:]))
+    pattern = "".join(pattern_parts)
+    return re.compile(f"^{pattern}$"), parameter_names
+
+
+def fill_uri_template(template: str, params: Dict[str, str]) -> str:
+    result = template
+    for key, value in params.items():
+        encoded = quote(value, safe="")
+        result = result.replace(f"{{{key}}}", encoded)
+    return result
+
+
+def normalize(value: Optional[str]) -> str:
+    if value is None:
+        return ""
+    return value.strip().lower()
+
+
+def parse_price(value: Optional[str]) -> Optional[float]:
+    if not value:
+        return None
+    match = re.search(r"-?\d+(?:\.\d+)?", value)
+    if not match:
+        return None
+    try:
+        parsed = float(match.group(0))
+    except ValueError:
+        return None
+    return parsed
+
+
+def compute_price_range(menu: List[Dict[str, Any]]) -> Optional[str]:
+    prices = [price for item in menu if (price := parse_price(item.get("price")))]
+    if not prices:
+        return None
+
+    min_price = min(prices)
+    max_price = max(prices)
+
+    def _format(val: float) -> str:
+        return f"${val:.0f}" if abs(val - round(val)) < 1e-9 else f"${val:.2f}"
+
+    if abs(min_price - max_price) < 0.01:
+        return _format(min_price)
+
+    return f"{_format(min_price)}–{_format(max_price)}"
+
+
+def _load_markers() -> Dict[str, Any]:
+    markers_path = REPO_ROOT / "src" / "pizzaz" / "markers.json"
+    try:
+        with markers_path.open("r", encoding="utf-8") as markers_file:
+            return json.load(markers_file)
+    except FileNotFoundError:
+        logger.warning("Markers dataset not found at %s; proceeding with empty menu", markers_path)
+    except json.JSONDecodeError as exc:
+        logger.error("Failed to decode markers dataset %s: %s", markers_path, exc)
+    return {"places": []}
+
+
+def _prepare_restaurants(places: List[Dict[str, Any]]) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    restaurants: List[Dict[str, Any]] = []
+    menu_items: List[Dict[str, Any]] = []
+
+    for place in places:
+        toppings_set = {
+            topping.strip()
+            for topping in (place.get("toppings") or [])
+            if isinstance(topping, str) and topping.strip()
+        }
+
+        sanitized_menu: List[Dict[str, Any]] = []
+        for item in place.get("menu") or []:
+            sanitized_toppings = [
+                topping.strip()
+                for topping in (item.get("toppings") or [])
+                if isinstance(topping, str) and topping.strip()
+            ]
+            toppings_set.update(sanitized_toppings)
+
+            sanitized_item = dict(item)
+            sanitized_item["toppings"] = sanitized_toppings
+            if not sanitized_item.get("image"):
+                sanitized_item["image"] = place.get("thumbnail")
+            sanitized_menu.append(sanitized_item)
+
+        price_range = compute_price_range(sanitized_menu)
+
+        restaurant = {
+            **place,
+            "toppings": sorted(toppings_set),
+            "menu": sanitized_menu,
+            "priceRange": price_range,
+        }
+        restaurants.append(restaurant)
+
+        for sanitized_item in sanitized_menu:
+            menu_items.append({**sanitized_item, "restaurant": restaurant})
+
+    return restaurants, menu_items
+
+
+_markers_data = _load_markers()
+_places = _markers_data.get("places", []) if isinstance(_markers_data, dict) else []
+RESTAURANTS, MENU_ITEMS = _prepare_restaurants(_places)
+
+RESTAURANTS_BY_ID: Dict[str, Dict[str, Any]] = {
+    normalize(restaurant.get("id")): restaurant
+    for restaurant in RESTAURANTS
+    if restaurant.get("id")
+}
+
+RESTAURANTS_BY_NORMALIZED_NAME: Dict[str, Dict[str, Any]] = {
+    normalize(restaurant.get("name")): restaurant
+    for restaurant in RESTAURANTS
+    if restaurant.get("name")
+}
+
+MENU_ITEMS_BY_ID: Dict[str, Dict[str, Any]] = {
+    normalize(item.get("id")): item
+    for item in MENU_ITEMS
+    if item.get("id")
+}
+
+MENU_ITEMS_BY_NORMALIZED_NAME: Dict[str, Dict[str, Any]] = {
+    normalize(item.get("name")): item
+    for item in MENU_ITEMS
+    if item.get("name")
+}
+
+ALL_TOPPINGS: List[str] = sorted(
+    {
+        topping
+        for item in MENU_ITEMS
+        for topping in item.get("toppings") or []
+        if isinstance(topping, str) and topping
+    },
+    key=lambda topping: topping.lower(),
+)
+
+TOPPINGS_BY_NORMALIZED: Dict[str, str] = {
+    normalize(topping): topping for topping in ALL_TOPPINGS
+}
+
+
+def find_topping(value: Optional[str]) -> Optional[str]:
+    if not value:
+        return None
+    return TOPPINGS_BY_NORMALIZED.get(normalize(value))
+
+
+def find_pizza(value: Optional[str]) -> Optional[Dict[str, Any]]:
+    if not value:
+        return None
+
+    normalized = normalize(value)
+    if normalized in MENU_ITEMS_BY_ID:
+        return MENU_ITEMS_BY_ID[normalized]
+    if normalized in MENU_ITEMS_BY_NORMALIZED_NAME:
+        return MENU_ITEMS_BY_NORMALIZED_NAME[normalized]
+
+    for item in MENU_ITEMS:
+        if normalize(item.get("name")) == normalized or normalize(item.get("id")) == normalized:
+            return item
+    return None
+
+MIME_TYPE = "text/html+skybridge"
+
+
+def widget_meta(
+    widget: PizzazWidget,
+    *,
+    output_template: Optional[str] = None,
+    include_parameter_schema: bool = False,
+    parameter_values: Optional[Dict[str, str]] = None,
+    resolved_uri: Optional[str] = None,
+) -> Dict[str, Any]:
+    meta: Dict[str, Any] = {
+        "openai/outputTemplate": output_template or widget.output_template,
+        "openai/toolInvocation/invoking": widget.invoking,
+        "openai/toolInvocation/invoked": widget.invoked,
+        "openai/widgetAccessible": True,
+        "openai/resultCanProduceWidget": True,
+        "annotations": {
+            "destructiveHint": False,
+            "openWorldHint": False,
+            "readOnlyHint": True,
+        },
+    }
+
+    if include_parameter_schema and widget.template_parameters:
+        schema: Dict[str, Any] = {}
+        for parameter in widget.template_parameters:
+            name = parameter.get("name")
+            if not name:
+                continue
+            entry: Dict[str, Any] = {"type": "string"}
+            description = parameter.get("description")
+            if description:
+                entry["description"] = description
+            schema[name] = entry
+        if schema:
+            meta["openai/outputTemplateSchema"] = schema
+
+    if parameter_values:
+        meta["openai/outputTemplateValues"] = parameter_values
+
+    if resolved_uri:
+        meta["openai/outputTemplateResolved"] = resolved_uri
+
+    return meta
+
+
+WidgetConfig = Dict[str, Any]
+
+_WIDGET_CONFIGS: List[WidgetConfig] = [
+    {
+        "identifier": "pizza-map",
+        "title": "Show Pizza Map",
+        "template_uri_base": "ui://widget/pizza-map.html",
+        "invoking": "Hand-tossing a map",
+        "invoked": "Served a fresh map",
+        "response_text": "Rendered a pizza map!",
+        "asset_name": "pizzaz",
+    },
+    {
+        "identifier": "pizza-carousel",
+        "title": "Show Pizza Carousel",
+        "template_uri_base": "ui://widget/pizza-carousel.html",
+        "invoking": "Carousel some spots",
+        "invoked": "Served a fresh carousel",
+        "response_text": "Rendered a pizza carousel!",
+        "asset_name": "pizzaz-carousel",
+    },
+    {
+        "identifier": "pizza-albums",
+        "title": "Show Pizza Album",
+        "template_uri_base": "ui://widget/pizza-albums.html",
+        "invoking": "Hand-tossing an album",
+        "invoked": "Served a fresh album",
+        "response_text": "Rendered a pizza album!",
+        "asset_name": "pizzaz-albums",
+    },
+    {
+        "identifier": "pizza-list",
+        "title": "Show Pizza List",
+        "template_uri_base": "ui://widget/pizza-list.html",
+        "invoking": "Hand-tossing a list",
+        "invoked": "Served a fresh list",
+        "response_text": "Rendered a pizza list!",
+        "asset_name": "pizzaz-list",
+        "dynamic_template": {
+            "uri_template_base": "ui://widget/pizza-list/{pizzaTopping}.html",
+            "description": "Pizza list widget filtered by topping.",
+            "parameters": [
+                {
+                    "name": "pizzaTopping",
+                    "description": "Name of the topping to highlight in the list.",
+                }
+            ],
+        },
+    },
+    {
+        "identifier": "pizza-video",
+        "title": "Show Pizza Video",
+        "template_uri_base": "ui://widget/pizza-video.html",
+        "invoking": "Hand-tossing a video",
+        "invoked": "Served a fresh video",
+        "response_text": "Rendered a pizza video!",
+        "asset_name": "pizzaz-video",
+    },
 ]
 
 
-MIME_TYPE = "text/html+skybridge"
+def _build_widget_collections() -> Tuple[
+    List[PizzazWidget],
+    List[types.Resource],
+    List[types.ResourceTemplate],
+    List[ResourceTemplateHandler],
+]:
+    widget_records: List[PizzazWidget] = []
+    resources: List[types.Resource] = []
+    resource_templates: List[types.ResourceTemplate] = []
+    template_handlers: List[ResourceTemplateHandler] = []
+
+    for config in _WIDGET_CONFIGS:
+        template_uri_base = config["template_uri_base"]
+        asset_name = config["asset_name"]
+        template_uri = f"{template_uri_base}{_version_suffix}"
+
+        dynamic_config = config.get("dynamic_template") or {}
+        output_template_base = dynamic_config.get("uri_template_base", template_uri_base)
+        output_template = f"{output_template_base}{_version_suffix}"
+
+        base_html = _build_widget_markup(asset_name)
+        template_parameters = [dict(param) for param in dynamic_config.get("parameters", [])]
+
+        widget = PizzazWidget(
+            identifier=config["identifier"],
+            title=config["title"],
+            template_uri=template_uri,
+            output_template=output_template,
+            invoking=config["invoking"],
+            invoked=config["invoked"],
+            base_html=base_html,
+            response_text=config["response_text"],
+            template_parameters=template_parameters,
+        )
+        widget_records.append(widget)
+
+        description = f"{widget.title} widget markup"
+        resource_meta = widget_meta(widget, output_template=widget.template_uri)
+
+        resources.append(
+            types.Resource(
+                name=widget.title,
+                uri=widget.template_uri,  # type: ignore[arg-type]
+                description=description,
+                mimeType=MIME_TYPE,
+                _meta=resource_meta,
+            )
+        )
+
+        static_template = types.ResourceTemplate(
+            name=widget.title,
+            uriTemplate=widget.template_uri,  # type: ignore[arg-type]
+            description=description,
+            mimeType=MIME_TYPE,
+            _meta=resource_meta,
+        )
+        resource_templates.append(static_template)
+
+        if dynamic_config:
+            dynamic_uri_template = f"{dynamic_config['uri_template_base']}{_version_suffix}"
+            pattern, parameter_names = compile_uri_template(dynamic_uri_template)
+            templated_description = dynamic_config.get(
+                "description",
+                f"{widget.title} widget markup (templated)",
+            )
+
+            render_callable = dynamic_config.get("render")
+            if callable(render_callable):
+                def _dynamic_render(params: Dict[str, str], _render=render_callable, _base_html=base_html) -> str:
+                    return _render(params, {"base_html": _base_html})
+                render_func = _dynamic_render
+            else:
+                def _static_render(params: Dict[str, str], _base_html=base_html) -> str:
+                    return append_template_params_script(_base_html, params)
+                render_func = _static_render
+
+            dynamic_meta = widget_meta(
+                widget,
+                output_template=dynamic_uri_template,
+                include_parameter_schema=True,
+            )
+
+            resource_templates.append(
+                types.ResourceTemplate(
+                    name=widget.title,
+                    uriTemplate=dynamic_uri_template,  # type: ignore[arg-type]
+                    description=templated_description,
+                    mimeType=MIME_TYPE,
+                    _meta=dynamic_meta,
+                )
+            )
+
+            template_handlers.append(
+                ResourceTemplateHandler(
+                    widget=widget,
+                    uri_template=dynamic_uri_template,
+                    pattern=pattern,
+                    parameter_names=parameter_names,
+                    render=render_func,
+                )
+            )
+
+    return widget_records, resources, resource_templates, template_handlers
+
+
+widgets, RESOURCES, RESOURCE_TEMPLATES, RESOURCE_TEMPLATE_HANDLERS = _build_widget_collections()
 
 
 WIDGETS_BY_ID: Dict[str, PizzazWidget] = {widget.identifier: widget for widget in widgets}
 WIDGETS_BY_URI: Dict[str, PizzazWidget] = {widget.template_uri: widget for widget in widgets}
 
 
-class PizzaInput(BaseModel):
-    """Schema for pizza tools."""
+class WidgetInput(BaseModel):
+    """Schema for widget tools that accept an optional topping filter."""
 
-    pizza_topping: str = Field(
-        ...,
+    pizza_topping: Optional[str] = Field(
+        default=None,
         alias="pizzaTopping",
         description="Topping to mention when rendering the widget.",
+    )
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+
+class PizzaDetailInput(BaseModel):
+    """Schema for the pizza detail tool."""
+
+    pizza_name: str = Field(
+        ...,
+        alias="pizzaName",
+        description="Name or identifier of the pizza to describe.",
     )
 
     model_config = ConfigDict(populate_by_name=True, extra="forbid")
@@ -133,7 +667,7 @@ mcp = FastMCP(
 )
 
 
-TOOL_INPUT_SCHEMA: Dict[str, Any] = {
+WIDGET_TOOL_INPUT_SCHEMA: Dict[str, Any] = {
     "type": "object",
     "properties": {
         "pizzaTopping": {
@@ -141,117 +675,275 @@ TOOL_INPUT_SCHEMA: Dict[str, Any] = {
             "description": "Topping to mention when rendering the widget.",
         }
     },
-    "required": ["pizzaTopping"],
+    "required": [],
     "additionalProperties": False,
 }
 
+AVAILABLE_TOPPINGS_TOOL_NAME = "list-pizza-toppings"
+AVAILABLE_TOPPINGS_TOOL_TITLE = "List Available Pizza Toppings"
 
-def _resource_description(widget: PizzazWidget) -> str:
-    return f"{widget.title} widget markup"
+AVAILABLE_TOPPINGS_TOOL_SCHEMA: Dict[str, Any] = {
+    "type": "object",
+    "properties": {},
+    "additionalProperties": False,
+}
 
+PIZZA_DETAIL_TOOL_NAME = "describe-pizza-toppings"
+PIZZA_DETAIL_TOOL_TITLE = "Describe Pizza Toppings"
 
-def _tool_meta(widget: PizzazWidget) -> Dict[str, Any]:
-    return {
-        "openai/outputTemplate": widget.template_uri,
-        "openai/toolInvocation/invoking": widget.invoking,
-        "openai/toolInvocation/invoked": widget.invoked,
-        "openai/widgetAccessible": True,
-        "openai/resultCanProduceWidget": True,
-        "annotations": {
-          "destructiveHint": False,
-          "openWorldHint": False,
-          "readOnlyHint": True,
+PIZZA_DETAIL_TOOL_SCHEMA: Dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "pizzaName": {
+            "type": "string",
+            "description": "Name or identifier of the pizza to describe.",
         }
-    }
-
-
-def _embedded_widget_resource(widget: PizzazWidget) -> types.EmbeddedResource:
-    return types.EmbeddedResource(
-        type="resource",
-        resource=types.TextResourceContents(
-            uri=widget.template_uri,
-            mimeType=MIME_TYPE,
-            text=widget.html,
-            title=widget.title,
-        ),
-    )
-
+    },
+    "required": ["pizzaName"],
+    "additionalProperties": False,
+}
 
 @mcp._mcp_server.list_tools()
 async def _list_tools() -> List[types.Tool]:
-    return [
+    widget_tools = [
         types.Tool(
             name=widget.identifier,
             title=widget.title,
             description=widget.title,
-            inputSchema=deepcopy(TOOL_INPUT_SCHEMA),
-            _meta=_tool_meta(widget),
+            inputSchema=deepcopy(WIDGET_TOOL_INPUT_SCHEMA),
+            _meta=widget_meta(widget, include_parameter_schema=True),
         )
         for widget in widgets
     ]
+
+    extra_tools = [
+        types.Tool(
+            name=AVAILABLE_TOPPINGS_TOOL_NAME,
+            title=AVAILABLE_TOPPINGS_TOOL_TITLE,
+            description="Lists every pizza topping supported by the Pizzaz widgets.",
+            inputSchema=deepcopy(AVAILABLE_TOPPINGS_TOOL_SCHEMA),
+            _meta={
+                "openai/widgetAccessible": False,
+                "openai/resultCanProduceWidget": False,
+            },
+        ),
+        types.Tool(
+            name=PIZZA_DETAIL_TOOL_NAME,
+            title=PIZZA_DETAIL_TOOL_TITLE,
+            description="Lists the toppings for a specific pizza from the demo dataset.",
+            inputSchema=deepcopy(PIZZA_DETAIL_TOOL_SCHEMA),
+            _meta={
+                "openai/widgetAccessible": False,
+                "openai/resultCanProduceWidget": False,
+            },
+        ),
+    ]
+
+    return widget_tools + extra_tools
 
 
 @mcp._mcp_server.list_resources()
 async def _list_resources() -> List[types.Resource]:
-    return [
-        types.Resource(
-            name=widget.title,
-            title=widget.title,
-            uri=widget.template_uri,
-            description=_resource_description(widget),
-            mimeType=MIME_TYPE,
-            _meta=_tool_meta(widget),
-        )
-        for widget in widgets
-    ]
+    return [deepcopy(resource) for resource in RESOURCES]
 
 
 @mcp._mcp_server.list_resource_templates()
 async def _list_resource_templates() -> List[types.ResourceTemplate]:
-    return [
-        types.ResourceTemplate(
-            name=widget.title,
-            title=widget.title,
-            uriTemplate=widget.template_uri,
-            description=_resource_description(widget),
-            mimeType=MIME_TYPE,
-            _meta=_tool_meta(widget),
-        )
-        for widget in widgets
-    ]
+    return [deepcopy(template) for template in RESOURCE_TEMPLATES]
 
 
 async def _handle_read_resource(req: types.ReadResourceRequest) -> types.ServerResult:
-    widget = WIDGETS_BY_URI.get(str(req.params.uri))
-    if widget is None:
-        return types.ServerResult(
-            types.ReadResourceResult(
-                contents=[],
-                _meta={"error": f"Unknown resource: {req.params.uri}"},
+    uri = str(req.params.uri)
+
+    widget = WIDGETS_BY_URI.get(uri)
+    if widget is not None:
+        contents: List[types.TextResourceContents | types.BlobResourceContents] = [
+            types.TextResourceContents(
+                uri=widget.template_uri,  # type: ignore[arg-type]
+                mimeType=MIME_TYPE,
+                text=widget.base_html,
+                _meta=widget_meta(
+                    widget,
+                    output_template=widget.template_uri,
+                    resolved_uri=widget.template_uri,
+                ),
             )
-        )
+        ]
+        return types.ServerResult(types.ReadResourceResult(contents=contents))
 
-    contents = [
-        types.TextResourceContents(
-            uri=widget.template_uri,
-            mimeType=MIME_TYPE,
-            text=widget.html,
-            _meta=_tool_meta(widget),
-        )
-    ]
+    for handler in RESOURCE_TEMPLATE_HANDLERS:
+        match = handler.pattern.match(uri)
+        if not match:
+            continue
 
-    return types.ServerResult(types.ReadResourceResult(contents=contents))
+        params: Dict[str, str] = {}
+        group_dict = match.groupdict()
+        for name in handler.parameter_names:
+            value = group_dict.get(name)
+            if not value:
+                continue
+            try:
+                decoded = unquote(value)
+            except Exception as exc:  # pragma: no cover - extremely unlikely
+                logger.warning("Failed to decode template parameter %s=%s: %s", name, value, exc)
+                decoded = value
+            params[name] = decoded
+
+        html = handler.render(params)
+        contents = [
+            types.TextResourceContents(
+                uri=uri,  # type: ignore[arg-type]
+                mimeType=MIME_TYPE,
+                text=html,
+                _meta=widget_meta(
+                    handler.widget,
+                    output_template=handler.uri_template,
+                    include_parameter_schema=True,
+                    parameter_values=params or None,
+                    resolved_uri=uri,
+                ),
+            )
+        ]
+        return types.ServerResult(types.ReadResourceResult(contents=contents))
+
+    return types.ServerResult(
+        types.ReadResourceResult(
+            contents=[],
+            _meta={"error": f"Unknown resource: {req.params.uri}"},
+        )
+    )
 
 
 async def _call_tool_request(req: types.CallToolRequest) -> types.ServerResult:
-    widget = WIDGETS_BY_ID.get(req.params.name)
+    tool_name = req.params.name
+
+    if tool_name == AVAILABLE_TOPPINGS_TOOL_NAME:
+        toppings_list = ALL_TOPPINGS
+        toppings_text = ", ".join(f"“{topping}”" for topping in toppings_list)
+        return types.ServerResult(
+            types.CallToolResult(
+                content=[
+                    types.TextContent(
+                        type="text",
+                        text=f"Here are the toppings you can request: {toppings_text}.",
+                    )
+                ],
+                structuredContent={"availableToppings": toppings_list},
+                _meta={
+                    "openai/widgetAccessible": False,
+                    "openai/resultCanProduceWidget": False,
+                },
+            )
+        )
+
+    if tool_name == PIZZA_DETAIL_TOOL_NAME:
+        arguments = req.params.arguments or {}
+        try:
+            payload = PizzaDetailInput.model_validate(arguments)
+        except ValidationError as exc:
+            return types.ServerResult(
+                types.CallToolResult(
+                    content=[
+                        types.TextContent(
+                            type="text",
+                            text=f"Input validation error: {exc.errors()}",
+                        )
+                    ],
+                    isError=True,
+                )
+            )
+
+        pizza = find_pizza(payload.pizza_name)
+        if pizza is None:
+            suggestions = ", ".join(
+                f"{item.get('name')} ({item.get('restaurant', {}).get('name')})"
+                for item in MENU_ITEMS[:6]
+            )
+            return types.ServerResult(
+                types.CallToolResult(
+                    content=[
+                        types.TextContent(
+                            type="text",
+                            text=f"I couldn’t find a pizza named “{payload.pizza_name}”. Try one of these: {suggestions}.",
+                        )
+                    ],
+                    structuredContent={
+                        "availablePizzas": [
+                            {
+                                "id": item.get("id"),
+                                "name": item.get("name"),
+                                "price": item.get("price"),
+                                "toppings": item.get("toppings") or [],
+                                "restaurant": {
+                                    "id": item.get("restaurant", {}).get("id"),
+                                    "name": item.get("restaurant", {}).get("name"),
+                                    "city": item.get("restaurant", {}).get("city"),
+                                    "rating": item.get("restaurant", {}).get("rating"),
+                                    "priceRange": item.get("restaurant", {}).get("priceRange"),
+                                },
+                            }
+                            for item in MENU_ITEMS
+                        ]
+                    },
+                    _meta={
+                        "openai/widgetAccessible": False,
+                        "openai/resultCanProduceWidget": False,
+                    },
+                )
+            )
+
+        restaurant = pizza.get("restaurant", {})
+        toppings = pizza.get("toppings") or []
+        toppings_text = (
+            ", ".join(f"“{topping}”" for topping in toppings)
+            if toppings
+            else "no recorded toppings"
+        )
+        price_fragment = f" It costs {pizza.get('price')}." if pizza.get("price") else ""
+
+        return types.ServerResult(
+            types.CallToolResult(
+                content=[
+                    types.TextContent(
+                        type="text",
+                        text=f"{pizza.get('name')} from {restaurant.get('name')} features {toppings_text}.{price_fragment}",
+                    )
+                ],
+                structuredContent={
+                    "pizza": {
+                        "id": pizza.get("id"),
+                        "name": pizza.get("name"),
+                        "description": pizza.get("description"),
+                        "price": pizza.get("price"),
+                        "toppings": toppings,
+                        "image": pizza.get("image"),
+                    },
+                    "restaurant": {
+                        "id": restaurant.get("id"),
+                        "name": restaurant.get("name"),
+                        "city": restaurant.get("city"),
+                        "description": restaurant.get("description"),
+                        "rating": restaurant.get("rating"),
+                        "thumbnail": restaurant.get("thumbnail"),
+                        "priceRange": restaurant.get("priceRange"),
+                    },
+                    "toppings": toppings,
+                },
+                _meta={
+                    "openai/widgetAccessible": False,
+                    "openai/resultCanProduceWidget": False,
+                },
+            )
+        )
+
+    widget = WIDGETS_BY_ID.get(tool_name)
     if widget is None:
         return types.ServerResult(
             types.CallToolResult(
                 content=[
                     types.TextContent(
                         type="text",
-                        text=f"Unknown tool: {req.params.name}",
+                        text=f"Unknown tool: {tool_name}",
                     )
                 ],
                 isError=True,
@@ -260,7 +952,7 @@ async def _call_tool_request(req: types.CallToolRequest) -> types.ServerResult:
 
     arguments = req.params.arguments or {}
     try:
-        payload = PizzaInput.model_validate(arguments)
+        payload = WidgetInput.model_validate(arguments)
     except ValidationError as exc:
         return types.ServerResult(
             types.CallToolResult(
@@ -274,27 +966,49 @@ async def _call_tool_request(req: types.CallToolRequest) -> types.ServerResult:
             )
         )
 
-    topping = payload.pizza_topping
-    widget_resource = _embedded_widget_resource(widget)
-    meta: Dict[str, Any] = {
-        "openai.com/widget": widget_resource.model_dump(mode="json"),
-        "openai/outputTemplate": widget.template_uri,
-        "openai/toolInvocation/invoking": widget.invoking,
-        "openai/toolInvocation/invoked": widget.invoked,
-        "openai/widgetAccessible": True,
-        "openai/resultCanProduceWidget": True,
-    }
+    raw_topping = (payload.pizza_topping or "").strip()
+    matched_topping = find_topping(raw_topping)
+    has_recognized_topping = bool(matched_topping)
+
+    parameter_values = (
+        {"pizzaTopping": matched_topping} if has_recognized_topping and widget.template_parameters else None
+    )
+
+    resolved_output_template = (
+        fill_uri_template(widget.output_template, parameter_values or {})
+        if has_recognized_topping
+        else widget.template_uri
+    )
+
+    meta_output_template = widget.output_template if has_recognized_topping else widget.template_uri
+
+    response_text = (
+        f"{widget.response_text} Filtered by “{matched_topping}”."
+        if has_recognized_topping and matched_topping
+        else f"{widget.response_text} Showing all pizzas."
+    )
 
     return types.ServerResult(
         types.CallToolResult(
             content=[
                 types.TextContent(
                     type="text",
-                    text=widget.response_text,
+                    text=response_text,
                 )
             ],
-            structuredContent={"pizzaTopping": topping},
-            _meta=meta,
+            structuredContent={
+                "pizzaTopping": matched_topping if has_recognized_topping else None,
+                "availableToppings": ALL_TOPPINGS,
+                "filterApplied": has_recognized_topping,
+                "requestedTopping": raw_topping or None,
+            },
+            _meta=widget_meta(
+                widget,
+                include_parameter_schema=True,
+                parameter_values=parameter_values,
+                resolved_uri=resolved_output_template,
+                output_template=meta_output_template,
+            ),
         )
     )
 
@@ -321,5 +1035,8 @@ except Exception:
 
 if __name__ == "__main__":
     import uvicorn
-
-    uvicorn.run("main:app", host="0.0.0.0", port=8000)
+    try:
+        _port = int(PORT or "8000")
+    except Exception:
+        _port = 8000
+    uvicorn.run(app, host="0.0.0.0", port=_port)

--- a/pizzaz_server_python/requirements.txt
+++ b/pizzaz_server_python/requirements.txt
@@ -1,3 +1,4 @@
 mcp[fastapi]>=0.1.0
 fastapi>=0.115.0
 uvicorn>=0.30.0
+python-dotenv>=1.0.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,6 +129,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^0.5.0
         version: 0.5.0
+      dotenv:
+        specifier: ^16.4.5
+        version: 16.6.1
       zod:
         specifier: ^3.23.8
         version: 3.25.76
@@ -1391,6 +1394,10 @@ packages:
 
   dompurify@3.2.6:
     resolution: {integrity: sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==}
+
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
 
   draco3d@1.5.7:
     resolution: {integrity: sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==}
@@ -3691,6 +3698,8 @@ snapshots:
   dompurify@3.2.6:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
+
+  dotenv@16.6.1: {}
 
   draco3d@1.5.7: {}
 

--- a/scripts/run-python-server.mjs
+++ b/scripts/run-python-server.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { resolve } from "node:path";
+import { existsSync } from "node:fs";
+import process from "node:process";
+
+const [, , scriptPath, ...scriptArgs] = process.argv;
+
+if (!scriptPath) {
+  console.error("Usage: node scripts/run-python-server.mjs <path-to-script> [args...]");
+  process.exit(1);
+}
+
+const resolvedScript = resolve(process.cwd(), scriptPath);
+
+if (!existsSync(resolvedScript)) {
+  console.error(`Cannot find Python entry point at ${resolvedScript}`);
+  process.exit(1);
+}
+
+const envPreferred = process.env.PYTHON || process.env.PYTHON_CMD;
+
+function tokenizeCommand(value) {
+  if (!value) {
+    return [];
+  }
+  const matches = value.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g);
+  if (!matches) {
+    return [];
+  }
+
+  return matches
+    .map((token) => {
+      const trimmed = token.trim();
+      if ((trimmed.startsWith("\"") && trimmed.endsWith("\"")) || (trimmed.startsWith("'") && trimmed.endsWith("'"))) {
+        return trimmed.slice(1, -1);
+      }
+      return trimmed;
+    })
+    .filter((token) => token.length > 0);
+}
+
+const candidates = [];
+
+if (envPreferred) {
+  const parsed = tokenizeCommand(envPreferred);
+  if (parsed.length > 0) {
+    candidates.push(parsed);
+  }
+}
+
+candidates.push(
+  ["python3", "-u"],
+  ["python", "-u"],
+  ["py", "-3", "-u"],
+  ["py", "-u"],
+);
+
+const errors = [];
+
+for (const candidate of candidates) {
+  if (!candidate || candidate.length === 0) {
+    continue;
+  }
+  const [cmd, ...baseArgs] = candidate;
+  const result = spawnSync(cmd, [...baseArgs, resolvedScript, ...scriptArgs], {
+    stdio: "inherit",
+    env: process.env,
+  });
+
+  if (result.status === 0) {
+    process.exit(0);
+  }
+
+  const reason = result.error?.message || `exit code ${result.status}`;
+  errors.push(`${cmd} ${baseArgs.join(" ")}`.trim() + ` (${reason})`);
+}
+
+console.error("Unable to start Python interpreter. Tried:\n" + errors.map((e) => `  - ${e}`).join("\n"));
+console.error("Set PYTHON or PYTHON_CMD env var to point at your interpreter if needed.");
+process.exit(1);

--- a/solar-system_server_python/.env.example
+++ b/solar-system_server_python/.env.example
@@ -1,0 +1,5 @@
+## Solar System MCP (Python) environment variables
+# Note: All variables are optional. With nothing set, the server defaults to CDN and sensible defaults.
+# ENVIRONMENT=local                           # Optional: 'local' or 'production' (default)
+# DOMAIN=http://localhost:4444                # Override dev/serve origin (leave unset for CDN)
+# PORT=8000                                   # Optional: change server port (default 8000)

--- a/solar-system_server_python/README.md
+++ b/solar-system_server_python/README.md
@@ -1,9 +1,6 @@
 # Solar system MCP server (Python)
 
-This directory packages a Python implementation of the solar-system demo server
-using the official Model Context Protocol FastMCP helper. It mirrors the widget
-experience shipped in this repository and lets you drive the 3D solar system UI
-from ChatGPT or the MCP Inspector.
+This directory packages a Python implementation of the solar-system demo server using the official Model Context Protocol FastMCP helper. It mirrors the widget experience shipped in this repository and lets you drive the 3D solar system UI from ChatGPT or the MCP Inspector. It shares configuration through a local `.env` file while falling back to the published CDN bundles whenever local assets are unavailable.
 
 ## Prerequisites
 
@@ -13,14 +10,18 @@ from ChatGPT or the MCP Inspector.
 ## Installation
 
 ```bash
+# Windows
+python -m venv .venv
+.venv\Scripts\activate
+pip install -r requirements.txt
+
+# Unix/Mac
 python -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
 ```
 
-> The requirements pin the official `mcp` distribution with its FastAPI extra. If
-you previously installed the unrelated `modelcontextprotocol` package, uninstall
-it first to avoid import conflicts.
+> The requirements pin the official `mcp` distribution with its FastAPI extra. If you previously installed the unrelated `modelcontextprotocol` package, uninstall it first to avoid import conflicts.
 
 ## Run the server
 
@@ -28,19 +29,47 @@ it first to avoid import conflicts.
 python main.py
 ```
 
-This boots a FastAPI app with uvicorn on `http://127.0.0.1:8000` (equivalently
-`uvicorn solar-system_server_python.main:app --port 8000`). The server exposes
-streaming endpoints compatible with the MCP Inspector and ChatGPT connectors:
+This boots a FastAPI app with uvicorn on `http://127.0.0.1:8000` (equivalently `uvicorn solar-system_server_python.main:app --port 8000`). The server exposes streaming endpoints compatible with the MCP Inspector and ChatGPT connectors:
 
 - `GET /mcp` provides the SSE stream.
 - `POST /mcp/messages?sessionId=...` receives follow-up messages for a session.
 
-Each tool call returns a small JSON payload describing the requested planet plus
-metadata that embeds the solar-system widget, so the Apps SDK can render the 3D
-experience inline.
+Configuration lives in `.env` in this directory. Update it before launching to control asset origin and port selection:
+
+```env
+# Use the Vite dev server started with `pnpm run dev`
+ENVIRONMENT=local
+
+# After `pnpm run build && pnpm run serve`, point to the static bundles
+# ENVIRONMENT=production
+# DOMAIN=http://localhost:4444
+
+# Change the default port (defaults to 8000)
+# PORT=8123
+```
+
+- When `ENVIRONMENT=local`, the widget hydrates from the Vite dev server without hashed filenames.
+- When `ENVIRONMENT=production` with a `DOMAIN`, assets are served from your local static server.
+- When `ENVIRONMENT` is omitted entirely—or local assets are missing—the server defaults to the CDN bundles (version `0038`).
+- Each tool call returns a JSON payload describing the requested planet plus metadata that embeds the solar-system widget so the Apps SDK can render the 3D experience inline.
+
+Prefer not to type the Python entry point directly? After activating the environment you can run:
+
+```bash
+pnpm start:solar-python
+```
+
+## Hot-swap reminder
+
+When you change `.env`, rebuild assets, or toggle between dev/static/CDN, don't delete the connector—just reopen it in ChatGPT (**Settings → Apps & Connectors → [your app] → Actions → Refresh app**). ChatGPT keeps the existing MCP base URL and fetches the newest widget templates right away. The repo [README](../README.md#hot-swap-modes-without-reconnecting) includes the full mode cheat sheet and VM considerations.
 
 ## Next steps
 
 - Expand the schema with additional celestial bodies or mission telemetry.
 - Source live ephemeris data to position planets in real time.
 - Gate access with authentication before exposing the widget in production.
+
+See main [README.md](../README.md) for:
+- Testing in ChatGPT
+- Architecture overview
+- Advanced configuration

--- a/solar-system_server_python/main.py
+++ b/solar-system_server_python/main.py
@@ -3,13 +3,100 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
+import os
+import json
+import time
+from dotenv import load_dotenv
 from typing import Any, Dict, List
+import re
 
 import mcp.types as types
 from mcp.server.fastmcp import FastMCP
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 MIME_TYPE = "text/html+skybridge"
+
+# Repo root for locating package.json if needed, and .env file
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Load .env from this server directory if present; OS env takes precedence
+try:
+    load_dotenv(REPO_ROOT / "solar-system_server_python" / ".env")
+except Exception:
+    pass
+
+# Asset configuration mirrors the Pizzaz servers
+CDN_BASE = "https://persistent.oaistatic.com/ecosystem-built-assets"
+CDN_VERSION = "0038"
+
+
+def _get_env(key: str) -> str | None:
+    return os.environ.get(key)
+
+
+# Environment variables - only these three are supported
+ENVIRONMENT = (_get_env("ENVIRONMENT") or "").strip()
+DOMAIN = (_get_env("DOMAIN") or "").strip() or None
+PORT = (_get_env("PORT") or "").strip() or None
+
+# Compute a default 4-char asset hash from package version
+ASSETS_DIR = REPO_ROOT / "assets"
+try:
+    with (REPO_ROOT / "package.json").open("r", encoding="utf-8") as _pkg:
+        _version = json.load(_pkg)["version"]
+except Exception:
+    _version = "0.0.0"
+import hashlib
+_default_asset_hash = hashlib.sha256(_version.encode("utf-8")).hexdigest()[:4]
+
+# Determine asset serving strategy based on ENVIRONMENT and DOMAIN
+_environment = ENVIRONMENT.lower()
+_is_env_local = _environment in {"local", "dev", "development"}
+
+if DOMAIN:
+    _dev_asset_origin = DOMAIN.rstrip("/")
+elif _is_env_local:
+    _dev_asset_origin = "http://localhost:4444"
+else:
+    _dev_asset_origin = None
+
+# When using the Vite dev server (`pnpm run dev`), assets are served without the hash suffix
+_dev_asset_hashed = not _is_env_local
+
+def _discover_asset_hash() -> str | None:
+    try:
+        candidates = sorted(
+            ASSETS_DIR.glob("solar-system-*.js"),
+            key=lambda p: p.stat().st_mtime,
+            reverse=True,
+        )
+    except FileNotFoundError:
+        return None
+    except OSError:
+        return None
+
+    pattern = re.compile(r"^solar-system-([0-9a-f]{4})\.js$")
+    for candidate in candidates:
+        match = pattern.match(candidate.name)
+        if match:
+            return match.group(1)
+    return None
+
+
+_asset_hash = (
+    (_get_env("ASSET_HASH") or "").strip().lower()
+    or (_discover_asset_hash() or _default_asset_hash).lower()
+)
+
+# Derive a version tag from the process start minute when serving un-hashed dev assets
+_is_dev_unhashed = bool(_dev_asset_origin) and (not _dev_asset_hashed)
+_auto_dev_version = None
+if _is_dev_unhashed:
+    _auto_dev_version = f"dev-{int(time.time() // 60):x}"
+
+_template_version = (_auto_dev_version or _asset_hash).lower()
+_version_suffix = f"?v={_template_version}" if _template_version else ""
 PLANETS = [
     "Mercury",
     "Venus",
@@ -56,19 +143,63 @@ class SolarWidget:
     response_text: str
 
 
+def _inline_widget_markup() -> str | None:
+    css_path = ASSETS_DIR / f"solar-system-{_asset_hash}.css"
+    js_path = ASSETS_DIR / f"solar-system-{_asset_hash}.js"
+    try:
+        css = css_path.read_text(encoding="utf-8")
+        js = js_path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+    except OSError:
+        return None
+
+    return (
+        '<div id="solar-system-root"></div>\n'
+        f"<style>\n{css}\n</style>\n"
+        f"<script type=\"module\">\n{js}\n</script>"
+    )
+
+
+def _solar_widget_html() -> str:
+    # Dev origin path (optionally hashed filenames) if configured
+    if _dev_asset_origin:
+        hash_segment = f"-{_asset_hash}" if _dev_asset_hashed else ""
+        css_href = f"{_dev_asset_origin}/solar-system{hash_segment}.css"
+        js_src = f"{_dev_asset_origin}/solar-system{hash_segment}.js"
+        return (
+            '<div id="solar-system-root"></div>\n'
+            f'<link rel="stylesheet" href="{css_href}">\n'
+            f'<script type="module" src="{js_src}"></script>'
+        )
+
+    if not ENVIRONMENT:
+        return (
+            '<div id="solar-system-root"></div>\n'
+            f'<link rel="stylesheet" href="{CDN_BASE}/solar-system-{CDN_VERSION}.css">\n'
+            f'<script type="module" src="{CDN_BASE}/solar-system-{CDN_VERSION}.js"></script>'
+        )
+
+    # Inline local hashed assets when available
+    inline = _inline_widget_markup()
+    if inline is not None:
+        return inline
+
+    # CDN fallback
+    return (
+        '<div id="solar-system-root"></div>\n'
+        f'<link rel="stylesheet" href="{CDN_BASE}/solar-system-{CDN_VERSION}.css">\n'
+        f'<script type="module" src="{CDN_BASE}/solar-system-{CDN_VERSION}.js"></script>'
+    )
+
+
 WIDGET = SolarWidget(
     identifier="solar-system",
     title="Explore the Solar System",
-    template_uri="ui://widget/solar-system.html",
+    template_uri=f"ui://widget/solar-system.html{_version_suffix}",
     invoking="Charting the solar system",
     invoked="Solar system ready",
-    html=(
-        "<div id=\"solar-system-root\"></div>\n"
-        "<link rel=\"stylesheet\" href=\"https://persistent.oaistatic.com/"
-        "ecosystem-built-assets/solar-system-0038.css\">\n"
-        "<script type=\"module\" src=\"https://persistent.oaistatic.com/"
-        "ecosystem-built-assets/solar-system-0038.js\"></script>"
-    ),
+    html=_solar_widget_html(),
     response_text="Solar system ready",
 )
 
@@ -112,21 +243,18 @@ def _tool_meta(widget: SolarWidget) -> Dict[str, Any]:
         "annotations": {
           "destructiveHint": False,
           "openWorldHint": False,
-          "readOnlyHint": True,
+          "readOnlyHint": True
         }
     }
 
 
 def _embedded_widget_resource(widget: SolarWidget) -> types.EmbeddedResource:
-    return types.EmbeddedResource(
-        type="resource",
-        resource=types.TextResourceContents(
-            uri=widget.template_uri,
-            mimeType=MIME_TYPE,
-            text=widget.html,
-            title=widget.title,
-        ),
+    text_contents = types.TextResourceContents(
+        uri=widget.template_uri,  # type: ignore[arg-type]
+        mimeType=MIME_TYPE,
+        text=widget.html,
     )
+    return types.EmbeddedResource(type="resource", resource=text_contents)
 
 
 def _normalize_planet(name: str) -> str | None:
@@ -175,7 +303,7 @@ async def _list_resources() -> List[types.Resource]:
         types.Resource(
             name=WIDGET.title,
             title=WIDGET.title,
-            uri=WIDGET.template_uri,
+            uri=WIDGET.template_uri,  # type: ignore[arg-type]
             description=_resource_description(WIDGET),
             mimeType=MIME_TYPE,
             _meta=_tool_meta(WIDGET),
@@ -189,7 +317,7 @@ async def _list_resource_templates() -> List[types.ResourceTemplate]:
         types.ResourceTemplate(
             name=WIDGET.title,
             title=WIDGET.title,
-            uriTemplate=WIDGET.template_uri,
+            uriTemplate=WIDGET.template_uri,  # type: ignore[arg-type]
             description=_resource_description(WIDGET),
             mimeType=MIME_TYPE,
             _meta=_tool_meta(WIDGET),
@@ -208,16 +336,18 @@ async def _handle_read_resource(req: types.ReadResourceRequest) -> types.ServerR
             )
         )
 
-    contents = [
+    contents: List[types.TextResourceContents | types.BlobResourceContents] = [
         types.TextResourceContents(
-            uri=WIDGET.template_uri,
+            uri=WIDGET.template_uri,  # type: ignore[arg-type]
             mimeType=MIME_TYPE,
             text=WIDGET.html,
             _meta=_tool_meta(WIDGET),
         )
     ]
 
-    return types.ServerResult(types.ReadResourceResult(contents=contents))
+    return types.ServerResult(
+        types.ReadResourceResult(contents=contents)  # type: ignore[arg-type,call-arg]
+    )
 
 
 async def _call_tool_request(req: types.CallToolRequest) -> types.ServerResult:
@@ -234,7 +364,7 @@ async def _call_tool_request(req: types.CallToolRequest) -> types.ServerResult:
                     )
                 ],
                 isError=True,
-            )
+            )  # type: ignore[call-arg]
         )
 
     planet = _normalize_planet(payload.planet_name)
@@ -251,7 +381,7 @@ async def _call_tool_request(req: types.CallToolRequest) -> types.ServerResult:
                     )
                 ],
                 isError=True,
-            )
+            )  # type: ignore[call-arg]
         )
 
     widget_resource = _embedded_widget_resource(WIDGET)
@@ -282,7 +412,7 @@ async def _call_tool_request(req: types.CallToolRequest) -> types.ServerResult:
             ],
             structuredContent=structured,
             _meta=meta,
-        )
+        )  # type: ignore[call-arg]
     )
 
 
@@ -307,5 +437,8 @@ except Exception:  # pragma: no cover - middleware is optional
 
 if __name__ == "__main__":
     import uvicorn
-
-    uvicorn.run("main:app", host="0.0.0.0", port=8000)
+    try:
+        _port = int(PORT or "8000")
+    except Exception:
+        _port = 8000
+    uvicorn.run(app, host="0.0.0.0", port=_port)

--- a/solar-system_server_python/requirements.txt
+++ b/solar-system_server_python/requirements.txt
@@ -2,3 +2,4 @@
 mcp[fastapi]>=0.1.0
 fastapi>=0.115.0
 uvicorn>=0.30.0
+python-dotenv>=1.0.1

--- a/src/pizzaz-carousel/PlaceCard.jsx
+++ b/src/pizzaz-carousel/PlaceCard.jsx
@@ -1,29 +1,41 @@
 import React from "react";
-import { Star } from "lucide-react";
+import { MapPin, Star } from "lucide-react";
 
-export default function PlaceCard({ place }) {
-  if (!place) return null;
+export default function PlaceCard({ item }) {
+  if (!item) return null;
+  const restaurant = item.restaurant ?? {};
   return (
     <div className="min-w-[220px] select-none max-w-[220px] w-[65vw] sm:w-[220px] self-stretch flex flex-col">
       <div className="w-full">
         <img
-          src={place.thumbnail}
-          alt={place.name}
+          src={item.image ?? restaurant.thumbnail}
+          alt={item.name}
           className="w-full aspect-square rounded-2xl object-cover ring ring-black/5 shadow-[0px_2px_6px_rgba(0,0,0,0.06)]"
         />
       </div>
       <div className="mt-3 flex flex-col flex-1">
-        <div className="text-base font-medium truncate line-clamp-1">{place.name}</div>
+        <div className="text-base font-medium truncate line-clamp-1">
+          {restaurant.name}
+        </div>
         <div className="text-xs mt-1 text-black/60 flex items-center gap-1">
           <Star className="h-3 w-3" aria-hidden="true" />
-          {place.rating?.toFixed ? place.rating.toFixed(1) : place.rating}
-          {place.price ? <span>· {place.price}</span> : null}
-          <span>· San Francisco</span>
+          {restaurant.rating?.toFixed ? restaurant.rating.toFixed(1) : restaurant.rating}
+          {restaurant.priceRange ? <span>· {restaurant.priceRange}</span> : null}
         </div>
-        {place.description ? (
-          <div className="text-sm mt-2 text-black/80 flex-auto">
-            {place.description}
+        <div className="text-xs mt-1 text-black/60 inline-flex items-center gap-1">
+          <MapPin className="h-3 w-3" aria-hidden="true" />
+          <span className="truncate">{restaurant.city ?? "San Francisco"}</span>
+        </div>
+        {item.description ? (
+          <div className="text-sm mt-2 text-black/80 flex-auto line-clamp-3">
+            {item.description}
           </div>
+        ) : null}
+        <div className="text-sm text-black/80 mt-2">
+          {item.name}
+        </div>
+        {item.price ? (
+          <div className="text-sm text-black/70">{item.price}</div>
         ) : null}
         <div className="mt-5">
           <button

--- a/src/pizzaz-carousel/index.jsx
+++ b/src/pizzaz-carousel/index.jsx
@@ -4,9 +4,34 @@ import useEmblaCarousel from "embla-carousel-react";
 import { ArrowLeft, ArrowRight } from "lucide-react";
 import markers from "../pizzaz/markers.json";
 import PlaceCard from "./PlaceCard";
+import { computePriceRange } from "../utils/price-range";
 
 function App() {
-  const places = markers?.places || [];
+  const menuItems = (markers?.places ?? []).flatMap((place) => {
+    const priceRange = computePriceRange(place.menu ?? []);
+    return (place.menu ?? []).map((item) => ({
+      ...item,
+      toppings: (item.toppings ?? []).map((topping) => topping.trim()).filter(Boolean),
+      restaurant: {
+        id: place.id,
+        name: place.name,
+        city: place.city,
+        rating: place.rating,
+        priceRange,
+        thumbnail: item.image ?? place.thumbnail,
+        description: place.description
+      }
+    }));
+  });
+
+  const sortedItems = [...menuItems].sort((a, b) => {
+    const ratingA = a.restaurant?.rating ?? 0;
+    const ratingB = b.restaurant?.rating ?? 0;
+    if (ratingA === ratingB) {
+      return (a.name || "").localeCompare(b.name || "");
+    }
+    return ratingB - ratingA;
+  });
   const [emblaRef, emblaApi] = useEmblaCarousel({
     align: "center",
     loop: false,
@@ -36,8 +61,8 @@ function App() {
     <div className="antialiased relative w-full text-black py-5 bg-white">
       <div className="overflow-hidden" ref={emblaRef}>
         <div className="flex gap-4 max-sm:mx-5 items-stretch">
-          {places.map((place) => (
-            <PlaceCard key={place.id} place={place} />
+          {sortedItems.map((item) => (
+            <PlaceCard key={item.id} item={item} />
           ))}
         </div>
       </div>

--- a/src/pizzaz-list/index.jsx
+++ b/src/pizzaz-list/index.jsx
@@ -2,9 +2,111 @@ import React from "react";
 import { createRoot } from "react-dom/client";
 import markers from "../pizzaz/markers.json";
 import { PlusCircle, Star } from "lucide-react";
+import { useOpenAiGlobal } from "../use-openai-global";
+import { computePriceRange } from "../utils/price-range";
+
+const defaultRestaurants = markers?.places ?? [];
+
+function resolveRequestedTopping({
+  templateParams,
+  metadata,
+  toolInput,
+  toppingsLookup,
+}) {
+  const sources = [
+    templateParams?.pizzaTopping,
+    metadata?.["openai/outputTemplateValues"]?.pizzaTopping,
+    toolInput?.pizzaTopping,
+  ];
+
+  for (const value of sources) {
+    if (typeof value !== "string") continue;
+    let decoded = value;
+    try {
+      decoded = decodeURIComponent(value);
+    } catch (error) {
+      // ignore decode errors and fall back to the original string
+    }
+    const trimmed = decoded.trim();
+    if (!trimmed) continue;
+    if (/^\{[^}]+\}$/.test(trimmed)) {
+      continue;
+    }
+    const normalized = trimmed.toLowerCase();
+    const canonical = toppingsLookup?.get(normalized);
+    if (!canonical) {
+      continue;
+    }
+    return canonical;
+  }
+
+  return "";
+}
 
 function App() {
-  const places = markers?.places || [];
+  const restaurants = React.useMemo(() => defaultRestaurants, []);
+  const menuItems = React.useMemo(() => {
+    return restaurants.flatMap((place) => {
+      const priceRange = computePriceRange(place.menu ?? []);
+      return (place.menu ?? []).map((item) => ({
+        ...item,
+        toppings: (item.toppings ?? []).map((topping) => topping.trim()).filter(Boolean),
+        restaurant: {
+          id: place.id,
+          name: place.name,
+          city: place.city,
+          rating: place.rating,
+          priceRange,
+          thumbnail: item.image ?? place.thumbnail,
+          baseThumbnail: place.thumbnail
+        }
+      }));
+    });
+  }, [restaurants]);
+
+  const toppingsByNormalized = React.useMemo(() => {
+    const map = new Map();
+    menuItems.forEach((item) => {
+      (item.toppings ?? []).forEach((topping) => {
+        const normalized = topping.trim().toLowerCase();
+        if (!normalized || map.has(normalized)) return;
+        map.set(normalized, topping);
+      });
+    });
+    return map;
+  }, [menuItems]);
+
+  const sortedMenuItems = React.useMemo(() => {
+    return [...menuItems].sort((a, b) => {
+      const ratingA = a.restaurant?.rating ?? 0;
+      const ratingB = b.restaurant?.rating ?? 0;
+      if (ratingA === ratingB) {
+        return (a.name || "").localeCompare(b.name || "");
+      }
+      return ratingB - ratingA;
+    });
+  }, [menuItems]);
+
+  const toolInput = useOpenAiGlobal("toolInput") ?? {};
+  const toolResponseMetadata = useOpenAiGlobal("toolResponseMetadata") ?? {};
+  const templateParams = window?.__PIZZAZ_TEMPLATE_PARAMS__ ?? {};
+  const requestedTopping = resolveRequestedTopping({
+    templateParams,
+    metadata: toolResponseMetadata,
+    toolInput,
+    toppingsLookup: toppingsByNormalized,
+  });
+  const normalizedTopping = requestedTopping.toLowerCase();
+  const filteredItems = normalizedTopping
+    ? sortedMenuItems.filter((item) =>
+        item.toppings?.some(
+          (topping) => topping.toLowerCase() === normalizedTopping,
+        ),
+      )
+    : sortedMenuItems;
+  const visibleItems = filteredItems;
+  const hasFilter = Boolean(requestedTopping);
+  const noResults = filteredItems.length === 0;
 
   return (
     <div className="antialiased w-full text-black px-4 pb-2 border border-black/10 rounded-2xl sm:rounded-3xl overflow-hidden bg-white">
@@ -34,54 +136,81 @@ function App() {
             </button>
           </div>
         </div>
-        <div className="min-w-full text-sm flex flex-col">
-          {places.slice(0, 7).map((place, i) => (
+        {hasFilter && (
+          <div className="flex items-center justify-between px-2 py-2 text-sm text-black/70">
+            <div>
+              Showing pizzas with topping:
+              <span className="ml-1 font-medium capitalize">{requestedTopping}</span>
+            </div>
+            <div className="hidden sm:block text-xs text-black/50">
+              {noResults ? "No matches" : `${filteredItems.length} matches`}
+            </div>
+          </div>
+        )}
+        <div
+          className="min-w-full text-sm flex flex-col overflow-y-auto overflow-x-hidden pr-1"
+          style={{ maxHeight: "calc(7 * 88px)" }}
+        >
+          {visibleItems.map((item, i) => (
             <div
-              key={place.id}
+              key={item.id}
               className="px-3 -mx-2 rounded-2xl hover:bg-black/5"
             >
               <div
+                className="flex flex-col gap-2 py-3 sm:grid sm:grid-cols-[minmax(0,2fr)_minmax(0,1fr)_auto] sm:items-center hover:border-black/0!"
                 style={{
                   borderBottom:
-                    i === 7 - 1 ? "none" : "1px solid rgba(0, 0, 0, 0.05)",
+                    i === visibleItems.length - 1 ? "none" : "1px solid rgba(0, 0, 0, 0.05)"
                 }}
-                className="flex w-full items-center hover:border-black/0! gap-2"
               >
-                <div className="py-3 pr-3 min-w-0 w-full sm:w-3/5">
-                  <div className="flex items-center gap-3">
-                    <img
-                      src={place.thumbnail}
-                      alt={place.name}
-                      className="h-10 w-10 sm:h-11 sm:w-11 rounded-lg object-cover ring ring-black/5"
-                    />
-                    <div className="w-3 text-end sm:block hidden text-sm text-black/40">
-                      {i + 1}
+                <div className="flex items-start gap-3 min-w-0">
+                  <div className="hidden sm:flex w-5 justify-end text-xs text-black/40 pt-1">
+                    {i + 1}
+                  </div>
+                  <img
+                    src={item.image ?? item.restaurant?.thumbnail ?? item.restaurant?.baseThumbnail}
+                    alt={item.name}
+                    className="h-10 w-10 sm:h-11 sm:w-11 rounded-lg object-cover ring ring-black/5"
+                  />
+                  <div className="min-w-0 flex flex-col">
+                    <div className="font-medium text-sm sm:text-md truncate">
+                      {item.name}
                     </div>
-                    <div className="min-w-0 sm:pl-1 flex flex-col items-start h-full">
-                      <div className="font-medium text-sm sm:text-md truncate max-w-[40ch]">
-                        {place.name}
+                    {item.description ? (
+                      <div className="text-xs text-black/60 mt-1 line-clamp-2">
+                        {item.description}
                       </div>
-                      <div className="mt-1 sm:mt-0.25 flex items-center gap-3 text-black/70 text-sm">
-                        <div className="flex items-center gap-1">
-                          <Star
-                            strokeWidth={1.5}
-                            className="h-3 w-3 text-black"
-                          />
-                          <span>
-                            {place.rating?.toFixed
-                              ? place.rating.toFixed(1)
-                              : place.rating}
-                          </span>
-                        </div>
-                        <div className="whitespace-nowrap sm:hidden">
-                          {place.city || "–"}
-                        </div>
+                    ) : null}
+                    {item.price ? (
+                      <div className="text-sm text-black/80 mt-1">{item.price}</div>
+                    ) : null}
+                    <div className="flex items-center gap-2 text-xs text-black/60 mt-2 sm:hidden">
+                      <span className="font-medium truncate">{item.restaurant?.name || "–"}</span>
+                      <span className="text-black/40 truncate max-w-[20ch]">
+                        {item.restaurant?.city || ""}
+                      </span>
+                      <div className="flex items-center gap-1">
+                        <Star strokeWidth={1.5} className="h-3 w-3 text-black" />
+                        <span>
+                          {item.restaurant?.rating?.toFixed
+                            ? item.restaurant.rating.toFixed(1)
+                            : item.restaurant?.rating}
+                        </span>
                       </div>
                     </div>
                   </div>
                 </div>
-                <div className="hidden sm:block text-end py-2 px-3 text-sm text-black/60 whitespace-nowrap flex-auto">
-                  {place.city || "–"}
+                <div className="hidden sm:flex flex-col text-right text-sm text-black/70 whitespace-nowrap">
+                  <span className="font-medium">{item.restaurant?.name || "–"}</span>
+                  <span className="text-xs text-black/50 mt-0.5">{item.restaurant?.city || ""}</span>
+                  <div className="flex items-center justify-end gap-1 text-xs text-black/60 mt-1">
+                    <Star strokeWidth={1.5} className="h-3 w-3 text-black" />
+                    <span>
+                      {item.restaurant?.rating?.toFixed
+                        ? item.restaurant.rating.toFixed(1)
+                        : item.restaurant?.rating}
+                    </span>
+                  </div>
                 </div>
                 <div className="py-2 whitespace-nowrap flex justify-end">
                   <PlusCircle strokeWidth={1.5} className="h-5 w-5" />
@@ -89,9 +218,9 @@ function App() {
               </div>
             </div>
           ))}
-          {places.length === 0 && (
+          {noResults && (
             <div className="py-6 text-center text-black/60">
-              No pizzerias found.
+              No pizzerias found{hasFilter ? ` for “${requestedTopping}”.` : "."}
             </div>
           )}
         </div>

--- a/src/pizzaz-video/index.css
+++ b/src/pizzaz-video/index.css
@@ -1,0 +1,3 @@
+@import "../index.css";
+
+/* pizzaz-video specific styles can go here if needed */

--- a/src/pizzaz-video/index.jsx
+++ b/src/pizzaz-video/index.jsx
@@ -1,0 +1,46 @@
+import React, { useMemo } from "react";
+import { createRoot } from "react-dom/client";
+import { useMaxHeight } from "../use-max-height";
+import { useOpenAiGlobal } from "../use-openai-global";
+
+const DEFAULT_VIDEO = "https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4";
+
+function VideoPlayer() {
+  const src = useMemo(() => {
+    const v = typeof window !== "undefined" ? window.__PIZZAZ_VIDEO_URL__ : undefined;
+    return typeof v === "string" && v.trim() ? v : DEFAULT_VIDEO;
+  }, []);
+
+  const maxHeight = useMaxHeight() ?? undefined;
+  const displayMode = useOpenAiGlobal("displayMode");
+  const containerHeight = typeof maxHeight === "number" && displayMode === "fullscreen"
+    ? Math.max(0, maxHeight - 40) // match spacing pattern used elsewhere
+    : 480; // sane default for inline mode
+
+  return (
+    <div
+      className="relative w-full border border-black/10 dark:border-white/10 rounded-2xl sm:rounded-3xl overflow-hidden bg-black"
+      style={{ maxHeight, height: containerHeight }}
+    >
+      <video
+        style={{ display: "block", width: "100%", height: "100%", objectFit: "cover" }}
+        src={src}
+        autoPlay
+        muted
+        loop
+        playsInline
+        controls
+      />
+    </div>
+  );
+}
+
+export default function App() {
+  return <VideoPlayer />;
+}
+
+// Mount to the standard root expected by the dev server and widget HTML
+const mountEl = document.getElementById("pizzaz-video-root");
+if (mountEl) {
+  createRoot(mountEl).render(<App />);
+}

--- a/src/pizzaz/Inspector.jsx
+++ b/src/pizzaz/Inspector.jsx
@@ -35,7 +35,7 @@ export default function Inspector({ place, onClose }) {
             <div className="text-sm mt-1 opacity-70 flex items-center gap-1">
               <Star className="h-3.5 w-3.5" aria-hidden="true" />
               {place.rating.toFixed(1)}
-              {place.price ? <span>· {place.price}</span> : null}
+              {place.priceRange ? <span>· {place.priceRange}</span> : null}
               <span>· San Francisco</span>
             </div>
             <div className="mt-3 flex flex-row items-center gap-3 font-medium">

--- a/src/pizzaz/Sidebar.jsx
+++ b/src/pizzaz/Sidebar.jsx
@@ -34,7 +34,7 @@ function PlaceListItem({ place, isSelected, onClick }) {
             <div className="text-xs mt-1 text-black/50 flex items-center gap-1">
               <Star className="h-3 w-3" aria-hidden="true" />
               {place.rating.toFixed(1)}
-              {place.price ? <span className="">· {place.price}</span> : null}
+              {place.priceRange ? <span className="">· {place.priceRange}</span> : null}
             </div>
           </div>
         </button>

--- a/src/pizzaz/index.jsx
+++ b/src/pizzaz/index.jsx
@@ -9,6 +9,7 @@ import Sidebar from "./Sidebar";
 import { useOpenAiGlobal } from "../use-openai-global";
 import { useMaxHeight } from "../use-max-height";
 import { Maximize2 } from "lucide-react";
+import { computePriceRange } from "../utils/price-range";
 import {
   useNavigate,
   useLocation,
@@ -38,7 +39,14 @@ export default function App() {
   const mapRef = useRef(null);
   const mapObj = useRef(null);
   const markerObjs = useRef([]);
-  const places = markers?.places || [];
+  const places = React.useMemo(
+    () =>
+      (markers?.places || []).map((place) => ({
+        ...place,
+        priceRange: computePriceRange(place.menu ?? [])
+      })),
+    []
+  );
   const markerCoords = places.map((p) => p.coords);
   const navigate = useNavigate();
   const location = useLocation();
@@ -72,10 +80,16 @@ export default function App() {
     requestAnimationFrame(() => mapObj.current.resize());
 
     // or keep it in sync with window resizes
-    window.addEventListener("resize", mapObj.current.resize);
+    const handleResize = () => {
+      if (mapObj.current) {
+        mapObj.current.resize();
+      }
+    };
+
+    window.addEventListener("resize", handleResize);
 
     return () => {
-      window.removeEventListener("resize", mapObj.current.resize);
+      window.removeEventListener("resize", handleResize);
       mapObj.current.remove();
     };
     // eslint-disable-next-line
@@ -242,7 +256,7 @@ export default function App() {
         >
           <div
             ref={mapRef}
-            className="w-full h-full absolute bottom-0 left-0 right-0"
+            className="absolute inset-0 w-full h-full"
             style={{
               maxHeight,
               height: displayMode === "fullscreen" ? maxHeight : undefined,

--- a/src/pizzaz/markers.json
+++ b/src/pizzaz/markers.json
@@ -6,9 +6,26 @@
       "coords": [-122.4098, 37.8001],
       "description": "Award‑winning Neapolitan pies in North Beach.",
       "city": "North Beach",
-      "rating": 4.8,
-      "price": "$$$",
-      "thumbnail": "https://persistent.oaistatic.com/pizzaz/pizzaz-1.png"
+  "rating": 4.8,
+      "thumbnail": "https://persistent.oaistatic.com/pizzaz/pizzaz-1.png",
+      "menu": [
+        {
+          "id": "nova-slice-supernova-margherita",
+          "name": "Supernova Margherita",
+          "description": "San Marzano tomatoes, fior di latte, basil oil swirl.",
+          "price": "$18",
+          "toppings": ["margherita", "basil", "mozzarella"],
+          "image": "https://persistent.oaistatic.com/pizzaz/pizzaz-1.png"
+        },
+        {
+          "id": "nova-slice-black-garlic-burrata",
+          "name": "Black Garlic Burrata",
+          "description": "Burrata, roasted garlic crema, truffle drizzle.",
+          "price": "$20",
+          "toppings": ["burrata", "truffle", "mozzarella"],
+          "image": "https://persistent.oaistatic.com/pizzaz/pizzaz-4.png"
+        }
+      ]
     },
     {
       "id": "midnight-marinara",
@@ -16,9 +33,26 @@
       "coords": [-122.4093, 37.7990],
       "description": "Focaccia‑style squares, late‑night favorite.",
       "city": "North Beach",
-      "rating": 4.6,
-      "price": "$",
-      "thumbnail": "https://persistent.oaistatic.com/pizzaz/pizzaz-2.png"
+  "rating": 4.6,
+      "thumbnail": "https://persistent.oaistatic.com/pizzaz/pizzaz-2.png",
+      "menu": [
+        {
+          "id": "midnight-pepperoni-crunch",
+          "name": "Midnight Pepperoni Crunch",
+          "description": "Crispy pepperoni cups, marinara, midnight spice blend.",
+          "price": "$16",
+          "toppings": ["pepperoni", "marinara", "mozzarella"],
+          "image": "https://persistent.oaistatic.com/pizzaz/pizzaz-2.png"
+        },
+        {
+          "id": "firefly-funghi",
+          "name": "Firefly Funghi",
+          "description": "Charred wild mushrooms, truffle cream, smoked salt.",
+          "price": "$17",
+          "toppings": ["mushroom", "truffle", "mozzarella"],
+          "image": "https://persistent.oaistatic.com/pizzaz/pizzaz-3.png"
+        }
+      ]
     },
     {
       "id": "cinder-oven-co",
@@ -26,9 +60,26 @@
       "coords": [-122.4255, 37.7613],
       "description": "Thin‑crust classics on 18th Street.",
       "city": "Mission",
-      "rating": 4.5,
-      "price": "$$",
-      "thumbnail": "https://persistent.oaistatic.com/pizzaz/pizzaz-3.png"
+  "rating": 4.5,
+      "thumbnail": "https://persistent.oaistatic.com/pizzaz/pizzaz-3.png",
+      "menu": [
+        {
+          "id": "cinder-crispy-diavola",
+          "name": "Crispy Diavola",
+          "description": "Spicy sausage, pickled peppers, charred crust.",
+          "price": "$17",
+          "toppings": ["sausage", "pepperoni", "marinara"],
+          "image": "https://persistent.oaistatic.com/pizzaz/pizzaz-5.png"
+        },
+        {
+          "id": "cinder-garden-spinach",
+          "name": "Garden Spinach",
+          "description": "Garlic spinach, roasted mushrooms, parmesan snow.",
+          "price": "$15",
+          "toppings": ["spinach", "mushroom", "mozzarella"],
+          "image": "https://persistent.oaistatic.com/pizzaz/pizzaz-6.png"
+        }
+      ]
     },
     {
       "id": "neon-crust-works",
@@ -36,9 +87,26 @@
       "coords": [-122.4388, 37.7775],
       "description": "Deep‑dish and cornmeal crust favorites.",
       "city": "Alamo Square",
-      "rating": 4.5,
-      "price": "$$",
-      "thumbnail": "https://persistent.oaistatic.com/pizzaz/pizzaz-6.png"
+  "rating": 4.5,
+      "thumbnail": "https://persistent.oaistatic.com/pizzaz/pizzaz-6.png",
+      "menu": [
+        {
+          "id": "neon-lava-pepperoni",
+          "name": "Lava Pepperoni",
+          "description": "Cornmeal deep dish, molten four-cheese blend.",
+          "price": "$22",
+          "toppings": ["deep-dish", "pepperoni", "four-cheese"],
+          "image": "https://persistent.oaistatic.com/pizzaz/pizzaz-2.png"
+        },
+        {
+          "id": "neon-smokehouse-sausage",
+          "name": "Smokehouse Sausage",
+          "description": "Smoked provolone, fennel sausage, caramelized onions.",
+          "price": "$21",
+          "toppings": ["sausage", "four-cheese", "deep-dish"],
+          "image": "https://persistent.oaistatic.com/pizzaz/pizzaz-5.png"
+        }
+      ]
     },
     {
       "id": "luna-pie-collective",
@@ -46,9 +114,26 @@
       "coords": [-122.4077, 37.7990],
       "description": "Wood‑fired pies and burrata in North Beach.",
       "city": "North Beach",
-      "rating": 4.6,
-      "price": "$$",
-      "thumbnail": "https://persistent.oaistatic.com/pizzaz/pizzaz-4.png"
+  "rating": 4.6,
+      "thumbnail": "https://persistent.oaistatic.com/pizzaz/pizzaz-4.png",
+      "menu": [
+        {
+          "id": "luna-moonlight-burrata",
+          "name": "Moonlight Burrata",
+          "description": "Burrata, lemon zest, basil pistou.",
+          "price": "$19",
+          "toppings": ["burrata", "basil", "white"],
+          "image": "https://persistent.oaistatic.com/pizzaz/pizzaz-4.png"
+        },
+        {
+          "id": "luna-harvest-white",
+          "name": "Harvest White",
+          "description": "Charred corn, whipped ricotta, chili honey.",
+          "price": "$18",
+          "toppings": ["white", "mozzarella", "seasonal"],
+          "image": "https://persistent.oaistatic.com/pizzaz/pizzaz-1.png"
+        }
+      ]
     },
     {
       "id": "bricklight-deep-dish",
@@ -56,9 +141,26 @@
       "coords": [-122.4097, 37.7992],
       "description": "Chicago‑style pies from Tony Gemignani.",
       "city": "North Beach",
-      "rating": 4.4,
-      "price": "$$$",
-      "thumbnail": "https://persistent.oaistatic.com/pizzaz/pizzaz-5.png"
+  "rating": 4.4,
+      "thumbnail": "https://persistent.oaistatic.com/pizzaz/pizzaz-5.png",
+      "menu": [
+        {
+          "id": "bricklight-heritage-spinach",
+          "name": "Heritage Spinach",
+          "description": "Layered spinach, artichoke cream, parmesan crust.",
+          "price": "$23",
+          "toppings": ["spinach", "deep-dish", "mozzarella"],
+          "image": "https://persistent.oaistatic.com/pizzaz/pizzaz-6.png"
+        },
+        {
+          "id": "bricklight-classic-sausage",
+          "name": "Classic Sausage",
+          "description": "Sausage crumble, caramelized onions, roasted peppers.",
+          "price": "$24",
+          "toppings": ["sausage", "pepperoni", "deep-dish"],
+          "image": "https://persistent.oaistatic.com/pizzaz/pizzaz-5.png"
+        }
+      ]
     },
     {
       "id": "garden-ember-pies",
@@ -66,9 +168,26 @@
       "coords": [-122.4380, 37.7722],
       "description": "Neighborhood spot with seasonal toppings.",
       "city": "Lower Haight",
-      "rating": 4.4,
-      "price": "$$",
-      "thumbnail": "https://persistent.oaistatic.com/pizzaz/pizzaz-1.png"
+  "rating": 4.4,
+      "thumbnail": "https://persistent.oaistatic.com/pizzaz/pizzaz-1.png",
+      "menu": [
+        {
+          "id": "garden-greenmarket",
+          "name": "Greenmarket",
+          "description": "Roasted seasonal vegetables, basil pesto, mozzarella.",
+          "price": "$17",
+          "toppings": ["veggie", "seasonal", "mozzarella"],
+          "image": "https://persistent.oaistatic.com/pizzaz/pizzaz-1.png"
+        },
+        {
+          "id": "garden-forest-mushroom",
+          "name": "Forest Mushroom",
+          "description": "Wild mushrooms, smoked gouda, thyme butter.",
+          "price": "$18",
+          "toppings": ["mushroom", "spinach", "mozzarella"],
+          "image": "https://persistent.oaistatic.com/pizzaz/pizzaz-3.png"
+        }
+      ]
     },
     {
       "id": "atlas-fire-pizzeria",
@@ -76,9 +195,26 @@
       "coords": [-122.4123, 37.7899],
       "description": "Sourdough, wood‑fired pies near Nob Hill.",
       "city": "Nob Hill",
-      "rating": 4.6,
-      "price": "$$$",
-      "thumbnail": "https://persistent.oaistatic.com/pizzaz/pizzaz-2.png"
+  "rating": 4.6,
+      "thumbnail": "https://persistent.oaistatic.com/pizzaz/pizzaz-2.png",
+      "menu": [
+        {
+          "id": "atlas-summit-sourdough",
+          "name": "Summit Sourdough",
+          "description": "Naturally leavened crust, marinated tomatoes, basil.",
+          "price": "$19",
+          "toppings": ["sourdough", "margherita", "basil"],
+          "image": "https://persistent.oaistatic.com/pizzaz/pizzaz-2.png"
+        },
+        {
+          "id": "atlas-prosciutto-lift",
+          "name": "Prosciutto Lift",
+          "description": "Prosciutto ribbons, arugula, lemon oil.",
+          "price": "$21",
+          "toppings": ["prosciutto", "sourdough", "mozzarella"],
+          "image": "https://persistent.oaistatic.com/pizzaz/pizzaz-6.png"
+        }
+      ]
     },
     {
       "id": "circuit-slice-garage",
@@ -86,9 +222,26 @@
       "coords": [-122.4135, 37.7805],
       "description": "Crispy‑edged Detroit‑style in SoMa.",
       "city": "SoMa",
-      "rating": 4.5,
-      "price": "$$",
-      "thumbnail": "https://persistent.oaistatic.com/pizzaz/pizzaz-3.png"
+  "rating": 4.5,
+      "thumbnail": "https://persistent.oaistatic.com/pizzaz/pizzaz-3.png",
+      "menu": [
+        {
+          "id": "circuit-turbo-detroit",
+          "name": "Turbo Detroit",
+          "description": "Triple cheese frico edge, spicy pepperoni oil.",
+          "price": "$20",
+          "toppings": ["detroit", "pepperoni", "four-cheese"],
+          "image": "https://persistent.oaistatic.com/pizzaz/pizzaz-3.png"
+        },
+        {
+          "id": "circuit-truffle-drive",
+          "name": "Truffle Drive",
+          "description": "Truffle cream, Yukon potatoes, crispy shallots.",
+          "price": "$21",
+          "toppings": ["truffle", "four-cheese", "mozzarella"],
+          "image": "https://persistent.oaistatic.com/pizzaz/pizzaz-5.png"
+        }
+      ]
     },
     {
       "id": "velvet-mozza-lounge",
@@ -96,9 +249,26 @@
       "coords": [-122.4019, 37.7818],
       "description": "Bianca pies and cocktails near Yerba Buena.",
       "city": "Yerba Buena",
-      "rating": 4.3,
-      "price": "$$",
-      "thumbnail": "https://persistent.oaistatic.com/pizzaz/pizzaz-6.png"
+  "rating": 4.3,
+      "thumbnail": "https://persistent.oaistatic.com/pizzaz/pizzaz-6.png",
+      "menu": [
+        {
+          "id": "velvet-satin-bianca",
+          "name": "Satin Bianca",
+          "description": "White sauce, mozzarella cloud, chive oil.",
+          "price": "$18",
+          "toppings": ["bianca", "mozzarella", "white"],
+          "image": "https://persistent.oaistatic.com/pizzaz/pizzaz-6.png"
+        },
+        {
+          "id": "velvet-prosciutto-fizz",
+          "name": "Prosciutto Fizz",
+          "description": "Prosciutto, whipped mascarpone, pink peppercorn.",
+          "price": "$19",
+          "toppings": ["prosciutto", "mozzarella", "truffle"],
+          "image": "https://persistent.oaistatic.com/pizzaz/pizzaz-4.png"
+        }
+      ]
     }
   ]
 }

--- a/src/utils/price-range.js
+++ b/src/utils/price-range.js
@@ -1,0 +1,34 @@
+export function computePriceRange(menu) {
+  if (!Array.isArray(menu) || menu.length === 0) {
+    return null;
+  }
+
+  const numericPrices = menu
+    .map((item) => {
+      if (!item || typeof item.price !== "string") {
+        return null;
+      }
+      const match = item.price.match(/-?\d+(?:\.\d+)?/);
+      if (!match) {
+        return null;
+      }
+      const value = Number.parseFloat(match[0]);
+      return Number.isNaN(value) ? null : value;
+    })
+    .filter((value) => value !== null);
+
+  if (numericPrices.length === 0) {
+    return null;
+  }
+
+  const min = Math.min(...numericPrices);
+  const max = Math.max(...numericPrices);
+  const format = (value) =>
+    `$${Number.isInteger(value) ? value.toFixed(0) : value.toFixed(2)}`;
+
+  if (Math.abs(min - max) < 0.01) {
+    return format(min);
+  }
+
+  return `${format(min)}–${format(max)}`;
+}


### PR DESCRIPTION
Implements parametrized resource URIs for MCP widgets, enabling runtime template resolution and SSR-like functionality.

### Changes
- Unified template-URI handling between Node and Python demos
- Added Pizzaz toolset with toppings search and pizza-detail handlers using `meta.openai/outputTemplate*` fields
- Streamlined asset delivery with auto-inlining and CDN fallback
- Updated build pipeline for hashed bundles and clean URLs
- Refreshed README and .env samples with new workflow documentation

### How it works
Tools can now return parametrized templates like `ui://widget/pizza-list/{pizzaTopping}` that get resolved dynamically at runtime instead of being statically cached.

Fixes #47