### PR TITLE
Fix: Keep canonical bundles & align widget URIs

### DIFF
--- a/build-all.mts
+++ b/build-all.mts
@@ -153,10 +153,10 @@ for (const out of outputs) {
   const dir = path.dirname(out);
   const ext = path.extname(out);
   const base = path.basename(out, ext);
-  const newName = path.join(dir, `${base}-${h}${ext}`);
+  const hashedPath = path.join(dir, `${base}-${h}${ext}`);
 
-  fs.renameSync(out, newName);
-  console.log(`${out} -> ${newName}`);
+  fs.copyFileSync(out, hashedPath);
+  console.log(`${out} -> ${hashedPath} (copied)`);
 }
 console.groupEnd();
 

--- a/pizzaz_server_node/src/server.ts
+++ b/pizzaz_server_node/src/server.ts
@@ -88,7 +88,7 @@ const widgets: PizzazWidget[] = [
   {
     id: "pizza-map",
     title: "Show Pizza Map",
-    templateUri: "ui://widget/pizza-map.html",
+    templateUri: "ui://widget/pizzaz.html",
     invoking: "Hand-tossing a map",
     invoked: "Served a fresh map",
     html: readWidgetHtml("pizzaz"),
@@ -97,7 +97,7 @@ const widgets: PizzazWidget[] = [
   {
     id: "pizza-carousel",
     title: "Show Pizza Carousel",
-    templateUri: "ui://widget/pizza-carousel.html",
+    templateUri: "ui://widget/pizzaz-carousel.html",
     invoking: "Carousel some spots",
     invoked: "Served a fresh carousel",
     html: readWidgetHtml("pizzaz-carousel"),
@@ -106,7 +106,7 @@ const widgets: PizzazWidget[] = [
   {
     id: "pizza-albums",
     title: "Show Pizza Album",
-    templateUri: "ui://widget/pizza-albums.html",
+    templateUri: "ui://widget/pizzaz-albums.html",
     invoking: "Hand-tossing an album",
     invoked: "Served a fresh album",
     html: readWidgetHtml("pizzaz-albums"),
@@ -115,7 +115,7 @@ const widgets: PizzazWidget[] = [
   {
     id: "pizza-list",
     title: "Show Pizza List",
-    templateUri: "ui://widget/pizza-list.html",
+    templateUri: "ui://widget/pizzaz-list.html",
     invoking: "Hand-tossing a list",
     invoked: "Served a fresh list",
     html: readWidgetHtml("pizzaz-list"),

--- a/pizzaz_server_python/main.py
+++ b/pizzaz_server_python/main.py
@@ -54,7 +54,7 @@ widgets: List[PizzazWidget] = [
     PizzazWidget(
         identifier="pizza-map",
         title="Show Pizza Map",
-        template_uri="ui://widget/pizza-map.html",
+        template_uri="ui://widget/pizzaz.html",
         invoking="Hand-tossing a map",
         invoked="Served a fresh map",
         html=_load_widget_html("pizzaz"),
@@ -63,7 +63,7 @@ widgets: List[PizzazWidget] = [
     PizzazWidget(
         identifier="pizza-carousel",
         title="Show Pizza Carousel",
-        template_uri="ui://widget/pizza-carousel.html",
+        template_uri="ui://widget/pizzaz-carousel.html",
         invoking="Carousel some spots",
         invoked="Served a fresh carousel",
         html=_load_widget_html("pizzaz-carousel"),
@@ -72,7 +72,7 @@ widgets: List[PizzazWidget] = [
     PizzazWidget(
         identifier="pizza-albums",
         title="Show Pizza Album",
-        template_uri="ui://widget/pizza-albums.html",
+        template_uri="ui://widget/pizzaz-albums.html",
         invoking="Hand-tossing an album",
         invoked="Served a fresh album",
         html=_load_widget_html("pizzaz-albums"),
@@ -81,7 +81,7 @@ widgets: List[PizzazWidget] = [
     PizzazWidget(
         identifier="pizza-list",
         title="Show Pizza List",
-        template_uri="ui://widget/pizza-list.html",
+        template_uri="ui://widget/pizzaz-list.html",
         invoking="Hand-tossing a list",
         invoked="Served a fresh list",
         html=_load_widget_html("pizzaz-list"),


### PR DESCRIPTION
## Summary

* Keep **non-hashed** bundles in `assets/` so static/ChatGPT can fetch `/pizzaz.js|.css`, `/solar-system.js|.css`.
* **Copy** to hashed variants (`*-<hash>.*`) instead of renaming, so both exist.
* Update MCP server templates so widget URIs **exactly match** emitted filenames (e.g., `ui://widget/pizzaz.html`).

## Changes

* Post-build: create hashed copies, retain canonicals.
* Generate two HTMLs per entry:

  * `name.html` → `/${name}.js|.css`
  * `name-<hash>.html` → `/${name}-<hash>.js|.css`
* Ensure root IDs `${name}-root` match app mounts.

## Testing

* `pnpm run build && pnpm run serve`
* 200 OK for: `/pizzaz.js|.css`, `/pizzaz-<hash>.js|.css`, `/solar-system.js|.css`, `/solar-system-<hash>.*`
* Start Python: `uvicorn solar-system_server_python.main:app --port 8000`
* In ChatGPT, clear connector cache; widgets render via updated `ui://widget/...html`.

## Issues

* **Fixes #58**
* **Refs #53**
