### PR TITLE
fix: reference hashed asset filenames in generated HTML

### DIFF
--- a/build-all.mts
+++ b/build-all.mts
@@ -175,8 +175,8 @@ for (const name of builtNames) {
   const html = `<!doctype html>
 <html>
 <head>
-  <script type="module" src="${normalizedBaseUrl}/${name}.js"></script>
-  <link rel="stylesheet" href="${normalizedBaseUrl}/${name}.css">
+  <script type="module" src="${normalizedBaseUrl}/${name}-${h}.js"></script>
+  <link rel="stylesheet" href="${normalizedBaseUrl}/${name}-${h}.css">
 </head>
 <body>
   <div id="${name}-root"></div>


### PR DESCRIPTION
Generated HTML was referencing unhashed filenames (pizzaz.js) but actual files were hashed (pizzaz-2d2b.js), causing 404s.