### PR TITLE
Add additional resources section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,9 @@ This will be used to generate the HTML for the widgets so that they can serve st
 
 You are welcome to open issues or submit PRs to improve this app, however, please note that we may not review all suggestions.
 
+## 📚 Additional Resources
+- **[Cloudflare Vite Template](https://github.com/Toolbase-AI/openai-apps-sdk-cloudflare-vite-template)** - Template deployable to Cloudflare that automatically builds and generates typed cache-busted resources/widgets from components. By **[gching](https://github.com/gching)**
+
 ## License
 
 This project is licensed under the MIT License. See [LICENSE](./LICENSE) for details.


### PR DESCRIPTION
## Changes
* Thought it would be useful to include an additional resources section for the community to include anything that can help with using the OpenAI Apps SDK

* Added a template I created that automatically builds and registers typed cache-busted resources/widgets that can be referenced in the MCP server