### PR TITLE
fix: include hash suffix in HTML asset references

### DIFF
--- a/build-all.mts
+++ b/build-all.mts
@@ -175,8 +175,8 @@ for (const name of builtNames) {
   const html = `<!doctype html>
 <html>
 <head>
-  <script type="module" src="${normalizedBaseUrl}/${name}.js"></script>
-  <link rel="stylesheet" href="${normalizedBaseUrl}/${name}.css">
+  <script type="module" src="${normalizedBaseUrl}/${name}-${h}.js"></script>
+  <link rel="stylesheet" href="${normalizedBaseUrl}/${name}-${h}.css">
 </head>
 <body>
   <div id="${name}-root"></div>


### PR DESCRIPTION
Problem: Build system renames assets with hash (pizzaz-list.js → pizzaz-list-2d2b.js) but HTML still references non-hashed names, causing 404 errors.

Solution: Update HTML generation to reference hashed filenames.