### PR TITLE
fix(widget-state): guard setWidgetState when window.openai is undefined

### DIFF
--- a/src/use-widget-state.ts
+++ b/src/use-widget-state.ts
@@ -32,14 +32,14 @@ export function useWidgetState<T extends UnknownObject>(
       _setWidgetState((prevState) => {
         const newState = typeof state === "function" ? state(prevState) : state;
 
-        if (newState != null) {
+        if (newState != null && window.openai?.setWidgetState) {
           window.openai.setWidgetState(newState);
         }
 
         return newState;
       });
     },
-    [window.openai.setWidgetState]
+    [window.openai?.setWidgetState]
   );
 
   return [widgetState, setWidgetState] as const;


### PR DESCRIPTION
fix(widget-state): guard setWidgetState when window.openai is undefined

- Only call window.openai.setWidgetState when it exists
- Use optional chaining in the effect dependency to prevent errors
- Avoids runtime crashes in local development where window.openai may be absent