### PR TITLE
solar system server - widget html does not belong in tool response

### DIFF
--- a/solar-system_server_python/main.py
+++ b/solar-system_server_python/main.py
@@ -132,18 +132,6 @@ def _tool_meta(widget: SolarWidget) -> Dict[str, Any]:
     }
 
 
-def _embedded_widget_resource(widget: SolarWidget) -> types.EmbeddedResource:
-    return types.EmbeddedResource(
-        type="resource",
-        resource=types.TextResourceContents(
-            uri=widget.template_uri,
-            mimeType=MIME_TYPE,
-            text=widget.html,
-            title=widget.title,
-        ),
-    )
-
-
 def _normalize_planet(name: str) -> str | None:
     if not name:
         return DEFAULT_PLANET
@@ -266,15 +254,7 @@ async def _call_tool_request(req: types.CallToolRequest) -> types.ServerResult:
             )
         )
 
-    widget_resource = _embedded_widget_resource(WIDGET)
-    meta: Dict[str, Any] = {
-        "openai.com/widget": widget_resource.model_dump(mode="json"),
-        "openai/outputTemplate": WIDGET.template_uri,
-        "openai/toolInvocation/invoking": WIDGET.invoking,
-        "openai/toolInvocation/invoked": WIDGET.invoked,
-        "openai/widgetAccessible": True,
-        "openai/resultCanProduceWidget": True,
-    }
+    meta: Dict[str, Any] = _tool_meta(WIDGET)
 
     description = PLANET_DESCRIPTIONS.get(planet, "")
     structured = {


### PR DESCRIPTION
Tool call response does not need to include the widget html. widget html is provided on read resource request.

Apps SDK – Plan → Tools (Point to a component template): explains using openai/outputTemplate on the tool to point at a resource, and returning structuredContent in the tool result. The HTML is not embedded in the tool result. [OpenAI Apps SDK – Tools](https://developers.openai.com/apps-sdk/plan/tools)
Apps SDK – Build → MCP server: shows registering resources and that clients fetch the widget HTML via MCP ReadResource for the text/html+skybridge resource URI referenced by openai/outputTemplate. Also details tool result fields (structuredContent, content, _meta) without requiring HTML in the result. [OpenAI Apps SDK – MCP server](https://developers.openai.com/apps-sdk/build/mcp-server)

Supporting example (official repo pizza server), which follows this pattern:
main.pyLines 148-162
```python
def _tool_meta(widget: PizzazWidget) -> Dict[str, Any]:
    return {
        "openai/outputTemplate": widget.template_uri,
        "openai/toolInvocation/invoking": widget.invoking,
        "openai/toolInvocation/invoked": widget.invoked,
        "openai/widgetAccessible": True,
        "openai/resultCanProduceWidget": True,
    }


def _tool_invocation_meta(widget: PizzazWidget) -> Dict[str, Any]:
    return {
        "openai/toolInvocation/invoking": widget.invoking,
        "openai/toolInvocation/invoked": widget.invoked,
    }
``` 

The tool points to the template via openai/outputTemplate.
The widget HTML is returned only by ReadResource for that URI, not embedded in the tool response.