### PR TITLE
Fix: Handle undefined window.openai in local developmentFix: Handle undefined window.openai in local development

### DIFF
--- a/src/pizzaz-shop/index.tsx
+++ b/src/pizzaz-shop/index.tsx
@@ -58,12 +58,12 @@ const FILTERS: Array<{
   label: string;
   tag?: string;
 }> = [
-  { id: "all", label: "All" },
-  { id: "vegetarian", label: "Vegetarian", tag: "vegetarian" },
-  { id: "vegan", label: "Vegan", tag: "vegan" },
-  { id: "size", label: "Size", tag: "size" },
-  { id: "spicy", label: "Spicy", tag: "spicy" },
-];
+    { id: "all", label: "All" },
+    { id: "vegetarian", label: "Vegetarian", tag: "vegetarian" },
+    { id: "vegan", label: "Vegan", tag: "vegan" },
+    { id: "size", label: "Size", tag: "size" },
+    { id: "spicy", label: "Spicy", tag: "spicy" },
+  ];
 
 const INITIAL_CART_ITEMS: CartItem[] = [
   {
@@ -604,12 +604,12 @@ function App() {
   const modalParams =
     viewParams && typeof viewParams === "object"
       ? (viewParams as {
-          state?: unknown;
-          cartItems?: unknown;
-          subtotal?: unknown;
-          total?: unknown;
-          totalItems?: unknown;
-        })
+        state?: unknown;
+        cartItems?: unknown;
+        subtotal?: unknown;
+        total?: unknown;
+        totalItems?: unknown;
+      })
       : null;
 
   const modalState =
@@ -619,7 +619,9 @@ function App() {
 
   const isCartModalView = isModalView && modalState === "cart";
   const shouldShowCheckoutOnly =
-    isCheckoutRoute || (isModalView && !isCartModalView);
+    isCheckoutRoute ||
+    (isModalView && !isCartModalView) ||
+    (selectedCartItemId != null && typeof window.openai === "undefined");
   const wasModalViewRef = useRef(isModalView);
 
   useEffect(() => {
@@ -730,11 +732,11 @@ function App() {
         anchorRect == null
           ? undefined
           : {
-              top: anchorRect.top,
-              left: anchorRect.left,
-              width: anchorRect.width,
-              height: anchorRect.height,
-            };
+            top: anchorRect.top,
+            left: anchorRect.left,
+            width: anchorRect.width,
+            height: anchorRect.height,
+          };
 
       void (async () => {
         try {
@@ -886,8 +888,8 @@ function App() {
     const observer =
       typeof ResizeObserver !== "undefined"
         ? new ResizeObserver(() => {
-            requestAnimationFrame(updateItemColumnPlacement);
-          })
+          requestAnimationFrame(updateItemColumnPlacement);
+        })
         : null;
 
     observer?.observe(node);

--- a/src/use-widget-state.ts
+++ b/src/use-widget-state.ts
@@ -32,14 +32,14 @@ export function useWidgetState<T extends UnknownObject>(
       _setWidgetState((prevState) => {
         const newState = typeof state === "function" ? state(prevState) : state;
 
-        if (newState != null) {
+        if (newState != null && window.openai?.setWidgetState) {
           window.openai.setWidgetState(newState);
         }
 
         return newState;
       });
     },
-    [window.openai.setWidgetState]
+    [window.openai?.setWidgetState]
   );
 
   return [widgetState, setWidgetState] as const;


### PR DESCRIPTION
## Problem

Running the project locally (`pnpm dev`) results in a crash with:
```
Cannot read properties of undefined (reading 'setWidgetState')
```

This happens because the code assumes `window.openai` (part of the ChatGPT Apps SDK) is always available, but it's only present when running inside ChatGPT.

## Solution

Added null checks and graceful fallbacks:

1. **useWidgetState hook**: Added optional chaining when accessing `window.openai.setWidgetState`
2. **pizzaz-shop component**: Show product details inline when modal API is unavailable

## Behavior

### Before
- ❌ Crashes immediately on local dev server
- ❌ Blank page, no way to view components

### After
- ✅ Runs successfully in local development
- ✅ Shows product details inline (instead of modal) when clicking items
- ✅ Maintains original modal behavior in ChatGPT environment

## Testing

Tested locally with `pnpm dev`:
1. Page loads without errors
2. Can click on products to view details
3. All components render correctly

The changes are backward compatible and don't affect the ChatGPT environment.- Add null checks for window.openai.setWidgetState in useWidgetState hook
- Enable local development by showing product details inline when window.openai is unavailable
- Fixes crash that prevented local development with 'Cannot read properties of undefined' error

Before this change, running the project locally would crash because the code assumed window.openai (part of the ChatGPT Apps SDK) would always be available. Now the code gracefully handles both environments:
- In ChatGPT: Uses window.openai.requestModal() to open modals
- In local dev: Shows product details inline in the main view

This allows developers to run and test the UI components locally without errors.