### PR TITLE
fix: add MCP Python DNS rebinding settings to examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,14 @@ You will get a public URL that you can use to add your local server to ChatGPT i
 
 For example: `https://<custom_endpoint>.ngrok-free.app/mcp`
 
+> [!IMPORTANT]
+> The Python MCP SDK enforces DNS rebinding protection. When tunneling (for example via ngrok), allow your tunnel host before starting any Python server:
+>
+> ```bash
+> export MCP_ALLOWED_HOSTS="<custom_endpoint>.ngrok-free.app"
+> export MCP_ALLOWED_ORIGINS="https://<custom_endpoint>.ngrok-free.app"
+> ```
+
 Once you add a connector, you can use it in ChatGPT conversations.
 
 You can add your app to the conversation context by selecting it in the "More" options.

--- a/pizzaz_server_python/main.py
+++ b/pizzaz_server_python/main.py
@@ -9,6 +9,7 @@ handlers into an HTTP/SSE stack so you can run the server with uvicorn on port
 
 from __future__ import annotations
 
+import os
 from copy import deepcopy
 from dataclasses import dataclass
 from functools import lru_cache
@@ -17,6 +18,7 @@ from typing import Any, Dict, List
 
 import mcp.types as types
 from mcp.server.fastmcp import FastMCP
+from mcp.server.transport_security import TransportSecuritySettings
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 
@@ -122,9 +124,28 @@ class PizzaInput(BaseModel):
     model_config = ConfigDict(populate_by_name=True, extra="forbid")
 
 
+def _split_env_list(value: str | None) -> List[str]:
+    if not value:
+        return []
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def _transport_security_settings() -> TransportSecuritySettings:
+    allowed_hosts = _split_env_list(os.getenv("MCP_ALLOWED_HOSTS"))
+    allowed_origins = _split_env_list(os.getenv("MCP_ALLOWED_ORIGINS"))
+    if not allowed_hosts and not allowed_origins:
+        return TransportSecuritySettings(enable_dns_rebinding_protection=False)
+    return TransportSecuritySettings(
+        enable_dns_rebinding_protection=True,
+        allowed_hosts=allowed_hosts,
+        allowed_origins=allowed_origins,
+    )
+
+
 mcp = FastMCP(
     name="pizzaz-python",
     stateless_http=True,
+    transport_security=_transport_security_settings(),
 )
 
 

--- a/shopping_cart_python/main.py
+++ b/shopping_cart_python/main.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from typing import Any, Dict, List
 from uuid import uuid4
 
 import mcp.types as types
 from mcp.server.fastmcp import FastMCP
+from mcp.server.transport_security import TransportSecuritySettings
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 TOOL_NAME = "add_to_cart"
@@ -35,6 +37,24 @@ def _load_widget_html() -> str:
 
 
 SHOPPING_CART_HTML = _load_widget_html()
+
+
+def _split_env_list(value: str | None) -> List[str]:
+    if not value:
+        return []
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def _transport_security_settings() -> TransportSecuritySettings:
+    allowed_hosts = _split_env_list(os.getenv("MCP_ALLOWED_HOSTS"))
+    allowed_origins = _split_env_list(os.getenv("MCP_ALLOWED_ORIGINS"))
+    if not allowed_hosts and not allowed_origins:
+        return TransportSecuritySettings(enable_dns_rebinding_protection=False)
+    return TransportSecuritySettings(
+        enable_dns_rebinding_protection=True,
+        allowed_hosts=allowed_hosts,
+        allowed_origins=allowed_origins,
+    )
 
 
 class CartItem(BaseModel):
@@ -73,6 +93,7 @@ carts: Dict[str, List[Dict[str, Any]]] = {}
 mcp = FastMCP(
     name="ecommerce-python",
     stateless_http=True,
+    transport_security=_transport_security_settings(),
 )
 
 


### PR DESCRIPTION
  - Wire all Python MCP examples to `TransportSecuritySettings` so they honor `MCP_ALLOWED_HOSTS`/`MCP_ALLOWED_ORIGINS` and avoid 421 errors introduced by the MCP Python SDK DNS rebinding
    protection.
  - Update README with ngrok-focused env var guidance and move the note to the tunneling section; remove the extra TrustedHost middleware from pizzaz_server_python.