### PR TITLE
docs: fix authenticated Python server startup command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ uvicorn pizzaz_server_python.main:app --port 8000
 python -m venv .venv
 source .venv/bin/activate
 pip install -r authenticated_server_python/requirements.txt
-uvicorn authenticated_python_server.main:app --port 8000
+uvicorn authenticated_server_python.main:app --port 8000
 ```
 
 ### Solar system Python server


### PR DESCRIPTION
Fixes a module path typo in the README command so the authenticated Python server starts correctly (avoids ModuleNotFoundError).