### PR TITLE
fix authenticated_server_python WWW-Authenticate formatting

### DIFF
--- a/authenticated_server_python/main.py
+++ b/authenticated_server_python/main.py
@@ -229,7 +229,7 @@ def _build_www_authenticate_value(error: str, description: str) -> str:
     safe_error = error.replace('"', r"\"")
     safe_description = description.replace('"', r"\"")
     parts = [
-        f'error="{safe_error}"error_description="{safe_description}"',
+        f'error="{safe_error}", error_description="{safe_description}"',
     ]
     parts.append(f'resource_metadata="{PROTECTED_RESOURCE_METADATA_URL}"')
     return f"Bearer {', '.join(parts)}"


### PR DESCRIPTION
## Summary
This PR fixes a formatting bug in the OAuth challenge string returned by the Python authenticated MCP example.

## What was wrong
In `authenticated_server_python/main.py`, the generated `WWW-Authenticate` challenge concatenated `error` and `error_description` without a comma separator.

Before:
- `error="..."error_description="..."`

This produces a malformed challenge value and can cause OAuth clients to parse the auth hint inconsistently.

## Root cause
A missing delimiter in `_build_www_authenticate_value(...)` when composing challenge parameters.

## Fix
Add the missing comma+space between `error` and `error_description` in the formatted string.

After:
- `error="...", error_description="..."`

## Validation
- Triggered unauthenticated call to protected tool `see_past_orders` via `/mcp`.
- Confirmed `mcp/www_authenticate` now returns a correctly formatted challenge:
  - `Bearer error="invalid_request", error_description="No access token was provided", resource_metadata="..."`

## Scope
- Minimal change: one-line fix in one file.
- No behavior changes outside authenticated challenge formatting.
