### PR TITLE
Pin pre-commit hook revisions to immutable commits

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.2
+    rev: 3db93a2be6f214ed722bf7bce095ec1b1715422a
     hooks:
       - id: ruff-check
       - id: ruff-format
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c
     hooks:
       - id: check-yaml
       - id: check-json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 3db93a2be6f214ed722bf7bce095ec1b1715422a
+    rev: 3db93a2be6f214ed722bf7bce095ec1b1715422a  # v0.14.2
     hooks:
       - id: ruff-check
       - id: ruff-format
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # v6.0.0
     hooks:
       - id: check-yaml
       - id: check-json


### PR DESCRIPTION
## What's changing
Replace non-commit `rev:` values in `.pre-commit-config.yaml` with the exact commit those refs resolve to today.

## Why
Tags and branch names can be retargeted upstream; pinning to immutable commits keeps the selected code the same over time.
