### PR TITLE
refactor(node-servers): migrate kitchen_sink and pizzaz to Streamable HTTP

### DIFF
--- a/kitchen_sink_server_node/README.md
+++ b/kitchen_sink_server_node/README.md
@@ -23,4 +23,4 @@ pnpm --filter kitchen-sink-mcp-node start
 pnpm start
 ```
 
-The server listens on `http://localhost:8000/mcp` (SSE) and `POST /mcp/messages` for messages. You can change the port with `PORT=9000 pnpm start`.
+The server listens on `http://localhost:8000/mcp` and speaks MCP over the Streamable HTTP transport (single stateless endpoint). You can change the port with `PORT=9000 pnpm start`.

--- a/kitchen_sink_server_node/package.json
+++ b/kitchen_sink_server_node/package.json
@@ -8,10 +8,14 @@
     "start": "tsx src/server.ts"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^0.5.0",
+    "@modelcontextprotocol/sdk": "^1.26.0",
+    "cors": "^2.8.5",
+    "express": "^5.2.1",
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "@types/cors": "^2.8.17",
+    "@types/express": "^5.0.0",
     "tsx": "^4.19.2",
     "typescript": "^5.6.3"
   }

--- a/kitchen_sink_server_node/src/server.ts
+++ b/kitchen_sink_server_node/src/server.ts
@@ -5,20 +5,19 @@
  * - kitchen-sink-show: renders the widget with structured content, adding a processedAt/echoed demo.
  * - kitchen-sink-refresh: lightweight echo tool called from the widget via callTool.
  *
- * Uses @modelcontextprotocol/sdk over SSE transport. Make sure assets are built
- * (pnpm run build) so the widget HTML is available in /assets before starting.
+ * Uses @modelcontextprotocol/sdk over the Streamable HTTP transport. Make sure
+ * assets are built (pnpm run build) so the widget HTML is available in /assets
+ * before starting.
  */
-import {
-  createServer,
-  type IncomingMessage,
-  type ServerResponse,
-} from "node:http";
 import fs from "node:fs";
 import path from "node:path";
-import { URL, fileURLToPath } from "node:url";
+import { fileURLToPath } from "node:url";
+
+import cors from "cors";
+import express from "express";
 
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
-import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import {
   CallToolRequestSchema,
   ListResourceTemplatesRequestSchema,
@@ -121,7 +120,7 @@ const toolInputSchema = {
   },
   required: ["message"],
   additionalProperties: false,
-} as const;
+} satisfies Tool["inputSchema"];
 
 const refreshInputSchema = {
   type: "object",
@@ -130,7 +129,7 @@ const refreshInputSchema = {
   },
   required: ["message"],
   additionalProperties: false,
-} as const;
+} satisfies Tool["inputSchema"];
 
 const showParser = z.object({
   message: z.string(),
@@ -288,123 +287,43 @@ function createKitchenSinkServer(): Server {
   return server;
 }
 
-type SessionRecord = {
-  server: Server;
-  transport: SSEServerTransport;
-};
-
-const sessions = new Map<string, SessionRecord>();
-
-const ssePath = "/mcp";
-const postPath = "/mcp/messages";
-
-async function handleSseRequest(res: ServerResponse) {
-  res.setHeader("Access-Control-Allow-Origin", "*");
-  const server = createKitchenSinkServer();
-  const transport = new SSEServerTransport(postPath, res);
-  const sessionId = transport.sessionId;
-
-  sessions.set(sessionId, { server, transport });
-
-  transport.onclose = async () => {
-    sessions.delete(sessionId);
-    await server.close();
-  };
-
-  transport.onerror = (error) => {
-    console.error("SSE transport error", error);
-  };
-
-  try {
-    await server.connect(transport);
-  } catch (error) {
-    sessions.delete(sessionId);
-    console.error("Failed to start SSE session", error);
-    if (!res.headersSent) {
-      res.writeHead(500).end("Failed to establish SSE connection");
-    }
-  }
-}
-
-async function handlePostMessage(
-  req: IncomingMessage,
-  res: ServerResponse,
-  url: URL
-) {
-  res.setHeader("Access-Control-Allow-Origin", "*");
-  res.setHeader("Access-Control-Allow-Headers", "content-type");
-  const sessionId = url.searchParams.get("sessionId");
-
-  if (!sessionId) {
-    res.writeHead(400).end("Missing sessionId query parameter");
-    return;
-  }
-
-  const session = sessions.get(sessionId);
-
-  if (!session) {
-    res.writeHead(404).end("Unknown session");
-    return;
-  }
-
-  try {
-    await session.transport.handlePostMessage(req, res);
-  } catch (error) {
-    console.error("Failed to process message", error);
-    if (!res.headersSent) {
-      res.writeHead(500).end("Failed to process message");
-    }
-  }
-}
-
 const portEnv = Number(process.env.PORT ?? 8000);
 const port = Number.isFinite(portEnv) ? portEnv : 8000;
 
-const httpServer = createServer(
-  async (req: IncomingMessage, res: ServerResponse) => {
-    if (!req.url) {
-      res.writeHead(400).end("Missing URL");
-      return;
-    }
+const app = express();
+app.use(cors());
+app.use(express.json());
 
-    const url = new URL(req.url, `http://${req.headers.host ?? "localhost"}`);
+// Stateless Streamable HTTP: a fresh server + transport per request, with no
+// server-side session tracking. Replaces the legacy two-endpoint SSE design
+// (`/mcp` + `/mcp/messages?sessionId=...`) with a single MCP endpoint.
+app.all("/mcp", async (req, res) => {
+  const server = createKitchenSinkServer();
+  const transport = new StreamableHTTPServerTransport({
+    sessionIdGenerator: undefined,
+  });
 
-    if (
-      req.method === "OPTIONS" &&
-      (url.pathname === ssePath || url.pathname === postPath)
-    ) {
-      res.writeHead(204, {
-        "Access-Control-Allow-Origin": "*",
-        "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
-        "Access-Control-Allow-Headers": "content-type",
+  res.on("close", () => {
+    transport.close().catch(() => {});
+    server.close().catch(() => {});
+  });
+
+  try {
+    await server.connect(transport);
+    await transport.handleRequest(req, res, req.body);
+  } catch (error) {
+    console.error("MCP error:", error);
+    if (!res.headersSent) {
+      res.status(500).json({
+        jsonrpc: "2.0",
+        error: { code: -32603, message: "Internal server error" },
+        id: null,
       });
-      res.end();
-      return;
     }
-
-    if (req.method === "GET" && url.pathname === ssePath) {
-      await handleSseRequest(res);
-      return;
-    }
-
-    if (req.method === "POST" && url.pathname === postPath) {
-      await handlePostMessage(req, res, url);
-      return;
-    }
-
-    res.writeHead(404).end("Not Found");
   }
-);
-
-httpServer.on("clientError", (err: Error, socket) => {
-  console.error("HTTP client error", err);
-  socket.end("HTTP/1.1 400 Bad Request\r\n\r\n");
 });
 
-httpServer.listen(port, () => {
+app.listen(port, () => {
   console.log(`Kitchen Sink MCP server listening on http://localhost:${port}`);
-  console.log(`  SSE stream: GET http://localhost:${port}${ssePath}`);
-  console.log(
-    `  Message post endpoint: POST http://localhost:${port}${postPath}?sessionId=...`
-  );
+  console.log(`  MCP endpoint: http://localhost:${port}/mcp`);
 });

--- a/pizzaz_server_node/README.md
+++ b/pizzaz_server_node/README.md
@@ -21,7 +21,7 @@ If you prefer npm or yarn, adjust the command accordingly.
 pnpm start
 ```
 
-The script bootstraps the server over SSE (Server-Sent Events), which makes it compatible with the MCP Inspector as well as ChatGPT connectors. Once running you can list the tools and invoke any of the pizza experiences.
+The script bootstraps the server over the Streamable HTTP transport (single stateless `/mcp` endpoint, default port `8000`), which makes it compatible with the MCP Inspector as well as ChatGPT connectors. Once running you can list the tools and invoke any of the pizza experiences.
 
 Each tool responds with:
 

--- a/pizzaz_server_node/package.json
+++ b/pizzaz_server_node/package.json
@@ -8,10 +8,14 @@
     "start": "tsx src/server.ts"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^0.5.0",
+    "@modelcontextprotocol/sdk": "^1.26.0",
+    "cors": "^2.8.5",
+    "express": "^5.2.1",
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "@types/cors": "^2.8.17",
+    "@types/express": "^5.0.0",
     "tsx": "^4.19.2",
     "typescript": "^5.6.3"
   }

--- a/pizzaz_server_node/src/server.ts
+++ b/pizzaz_server_node/src/server.ts
@@ -1,14 +1,12 @@
-import {
-  createServer,
-  type IncomingMessage,
-  type ServerResponse,
-} from "node:http";
 import fs from "node:fs";
 import path from "node:path";
-import { URL, fileURLToPath } from "node:url";
+import { fileURLToPath } from "node:url";
+
+import cors from "cors";
+import express from "express";
 
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
-import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import {
   CallToolRequestSchema,
   ListResourceTemplatesRequestSchema,
@@ -156,7 +154,7 @@ const toolInputSchema = {
   },
   required: ["pizzaTopping"],
   additionalProperties: false,
-} as const;
+} satisfies Tool["inputSchema"];
 
 const toolInputParser = z.object({
   pizzaTopping: z.string(),
@@ -278,123 +276,43 @@ function createPizzazServer(): Server {
   return server;
 }
 
-type SessionRecord = {
-  server: Server;
-  transport: SSEServerTransport;
-};
-
-const sessions = new Map<string, SessionRecord>();
-
-const ssePath = "/mcp";
-const postPath = "/mcp/messages";
-
-async function handleSseRequest(res: ServerResponse) {
-  res.setHeader("Access-Control-Allow-Origin", "*");
-  const server = createPizzazServer();
-  const transport = new SSEServerTransport(postPath, res);
-  const sessionId = transport.sessionId;
-
-  sessions.set(sessionId, { server, transport });
-
-  transport.onclose = async () => {
-    sessions.delete(sessionId);
-    await server.close();
-  };
-
-  transport.onerror = (error) => {
-    console.error("SSE transport error", error);
-  };
-
-  try {
-    await server.connect(transport);
-  } catch (error) {
-    sessions.delete(sessionId);
-    console.error("Failed to start SSE session", error);
-    if (!res.headersSent) {
-      res.writeHead(500).end("Failed to establish SSE connection");
-    }
-  }
-}
-
-async function handlePostMessage(
-  req: IncomingMessage,
-  res: ServerResponse,
-  url: URL
-) {
-  res.setHeader("Access-Control-Allow-Origin", "*");
-  res.setHeader("Access-Control-Allow-Headers", "content-type");
-  const sessionId = url.searchParams.get("sessionId");
-
-  if (!sessionId) {
-    res.writeHead(400).end("Missing sessionId query parameter");
-    return;
-  }
-
-  const session = sessions.get(sessionId);
-
-  if (!session) {
-    res.writeHead(404).end("Unknown session");
-    return;
-  }
-
-  try {
-    await session.transport.handlePostMessage(req, res);
-  } catch (error) {
-    console.error("Failed to process message", error);
-    if (!res.headersSent) {
-      res.writeHead(500).end("Failed to process message");
-    }
-  }
-}
-
 const portEnv = Number(process.env.PORT ?? 8000);
 const port = Number.isFinite(portEnv) ? portEnv : 8000;
 
-const httpServer = createServer(
-  async (req: IncomingMessage, res: ServerResponse) => {
-    if (!req.url) {
-      res.writeHead(400).end("Missing URL");
-      return;
-    }
+const app = express();
+app.use(cors());
+app.use(express.json());
 
-    const url = new URL(req.url, `http://${req.headers.host ?? "localhost"}`);
+// Stateless Streamable HTTP: a fresh server + transport per request, with no
+// server-side session tracking. Replaces the legacy two-endpoint SSE design
+// (`/mcp` + `/mcp/messages?sessionId=...`) with a single MCP endpoint.
+app.all("/mcp", async (req, res) => {
+  const server = createPizzazServer();
+  const transport = new StreamableHTTPServerTransport({
+    sessionIdGenerator: undefined,
+  });
 
-    if (
-      req.method === "OPTIONS" &&
-      (url.pathname === ssePath || url.pathname === postPath)
-    ) {
-      res.writeHead(204, {
-        "Access-Control-Allow-Origin": "*",
-        "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
-        "Access-Control-Allow-Headers": "content-type",
+  res.on("close", () => {
+    transport.close().catch(() => {});
+    server.close().catch(() => {});
+  });
+
+  try {
+    await server.connect(transport);
+    await transport.handleRequest(req, res, req.body);
+  } catch (error) {
+    console.error("MCP error:", error);
+    if (!res.headersSent) {
+      res.status(500).json({
+        jsonrpc: "2.0",
+        error: { code: -32603, message: "Internal server error" },
+        id: null,
       });
-      res.end();
-      return;
     }
-
-    if (req.method === "GET" && url.pathname === ssePath) {
-      await handleSseRequest(res);
-      return;
-    }
-
-    if (req.method === "POST" && url.pathname === postPath) {
-      await handlePostMessage(req, res, url);
-      return;
-    }
-
-    res.writeHead(404).end("Not Found");
   }
-);
-
-httpServer.on("clientError", (err: Error, socket) => {
-  console.error("HTTP client error", err);
-  socket.end("HTTP/1.1 400 Bad Request\r\n\r\n");
 });
 
-httpServer.listen(port, () => {
+app.listen(port, () => {
   console.log(`Pizzaz MCP server listening on http://localhost:${port}`);
-  console.log(`  SSE stream: GET http://localhost:${port}${ssePath}`);
-  console.log(
-    `  Message post endpoint: POST http://localhost:${port}${postPath}?sessionId=...`
-  );
+  console.log(`  MCP endpoint: http://localhost:${port}/mcp`);
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,12 +173,24 @@ importers:
   kitchen_sink_server_node:
     dependencies:
       '@modelcontextprotocol/sdk':
-        specifier: ^0.5.0
-        version: 0.5.0
+        specifier: ^1.26.0
+        version: 1.26.0(zod@3.25.76)
+      cors:
+        specifier: ^2.8.5
+        version: 2.8.6
+      express:
+        specifier: ^5.2.1
+        version: 5.2.1
       zod:
         specifier: ^3.23.8
         version: 3.25.76
     devDependencies:
+      '@types/cors':
+        specifier: ^2.8.17
+        version: 2.8.19
+      '@types/express':
+        specifier: ^5.0.0
+        version: 5.0.6
       tsx:
         specifier: ^4.19.2
         version: 4.20.4
@@ -220,12 +232,24 @@ importers:
   pizzaz_server_node:
     dependencies:
       '@modelcontextprotocol/sdk':
-        specifier: ^0.5.0
-        version: 0.5.0
+        specifier: ^1.26.0
+        version: 1.26.0(zod@3.25.76)
+      cors:
+        specifier: ^2.8.5
+        version: 2.8.6
+      express:
+        specifier: ^5.2.1
+        version: 5.2.1
       zod:
         specifier: ^3.23.8
         version: 3.25.76
     devDependencies:
+      '@types/cors':
+        specifier: ^2.8.17
+        version: 2.8.19
+      '@types/express':
+        specifier: ^5.0.0
+        version: 5.0.6
       tsx:
         specifier: ^4.19.2
         version: 4.20.4
@@ -627,9 +651,6 @@ packages:
         optional: true
       react-dom:
         optional: true
-
-  '@modelcontextprotocol/sdk@0.5.0':
-    resolution: {integrity: sha512-RXgulUX6ewvxjAG0kOpLMEdXXWkzWgaoCGaA2CwNW7cQCIphjpJhjpHSiaPdVCnisjRF/0Cm9KWHUuIoeiAblQ==}
 
   '@modelcontextprotocol/sdk@1.26.0':
     resolution: {integrity: sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==}
@@ -4556,12 +4577,6 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.57.1
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
-
-  '@modelcontextprotocol/sdk@0.5.0':
-    dependencies:
-      content-type: 1.0.5
-      raw-body: 3.0.1
-      zod: 3.25.76
 
   '@modelcontextprotocol/sdk@1.26.0(zod@3.25.76)':
     dependencies:


### PR DESCRIPTION
## Summary

Closes #208.

The MCP spec [2025-06-18](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports) explicitly deprecates the HTTP+SSE transport from 2024-11-05 in favor of Streamable HTTP. This PR migrates the two remaining Node demos still on `SSEServerTransport` so the Node examples match the pattern already used by `cards_against_ai_server_node` and `mcp_app_basics_node`, and align with the Python demos which already serve Streamable HTTP via FastMCP.

### Per server (`kitchen_sink_server_node`, `pizzaz_server_node`)

- Bump `@modelcontextprotocol/sdk` from `^0.5.0` to `^1.26.0`
- Add `express ^5.2.1`, `cors ^2.8.5`, `@types/express`, `@types/cors`
- Replace the `node:http` server + `SSEServerTransport` plumbing (two-endpoint `/mcp` + `/mcp/messages?sessionId=...` design with a manual session map) with an Express app exposing a single stateless `/mcp` endpoint backed by `StreamableHTTPServerTransport` (`sessionIdGenerator: undefined`). A fresh `Server` + transport is created per request, mirroring the cards and basics servers.
- Keep the low-level `Server` class, all `setRequestHandler` handlers, and the widget asset loading logic **untouched**, so tool, resource, and `_meta` behavior is byte-for-byte equivalent to the previous SSE servers.
- Replace `as const` on the JSON Schema literals with `satisfies Tool[\"inputSchema\"]` so the schemas remain assignable to the SDK 1.x `Tool` type while keeping static shape checking.
- Update both READMEs to describe the new single-endpoint Streamable HTTP transport instead of SSE + `/mcp/messages`.

### Why

1. Removes use of a transport explicitly marked deprecated by the spec.
2. Closes drift inside the Node examples (was: 2 demos on legacy SSE, 2 on Streamable HTTP; now: 4 of 4 on Streamable HTTP).
3. Aligns Node with Python, which is already on Streamable HTTP across the board.
4. Likely defuses #107 (Pizzaz `localhost:8000` shows \"Not Found\") for users who probe the single MCP endpoint by hand instead of the legacy two-endpoint setup.

### Net diff

```
 kitchen_sink_server_node/README.md     |   2 +-
 kitchen_sink_server_node/package.json  |   6 +-
 kitchen_sink_server_node/src/server.ts | 149 +++++++--------------------------
 pizzaz_server_node/README.md           |   2 +-
 pizzaz_server_node/package.json        |   6 +-
 pizzaz_server_node/src/server.ts       | 142 ++++++++-----------------------
 pnpm-lock.yaml                         |  41 ++++++---
 7 files changed, 104 insertions(+), 244 deletions(-)
```

## Test plan

- [x] `npx tsc --noEmit` clean in `kitchen_sink_server_node`
- [x] `npx tsc --noEmit` clean in `pizzaz_server_node`
- [x] `pnpm --filter kitchen-sink-mcp-node start` boots, logs the new single `/mcp` endpoint
- [x] `pnpm --filter pizzaz-mcp-node start` boots, logs the new single `/mcp` endpoint
- [x] `POST /mcp` `initialize` returns `protocolVersion: 2025-06-18` (kitchen sink)
- [x] `POST /mcp` `tools/list` returns expected tools with full `_meta` (`openai/outputTemplate`, `openai/widgetAccessible`, etc.) preserved on both servers
- [ ] Connect from MCP Inspector and a ChatGPT developer-mode connector against both servers
- [ ] Exercise widget callbacks (`window.openai.callTool` for `kitchen-sink-refresh`, topping prompts for each pizzaz tool) end-to-end

## Out of scope

- Refactoring tool registration to `McpServer` + `registerAppTool` from `@modelcontextprotocol/ext-apps/server`. Could be a follow-up to fully match the cards/basics pattern, but kept narrow here to limit blast radius and behavioral risk.
- Python servers — already on Streamable HTTP.