### PR TITLE
Update examples to use apps-sdk-ui, update basics server to build widgets on start

### DIFF
--- a/build-all.mts
+++ b/build-all.mts
@@ -5,7 +5,6 @@ import fg from "fast-glob";
 import path from "path";
 import fs from "fs";
 import crypto from "crypto";
-import pkg from "./package.json" with { type: "json" };
 import tailwindcss from "@tailwindcss/vite";
 
 dotenv.config({ path: path.resolve(process.cwd(), ".env.local") });
@@ -42,11 +41,39 @@ const targets: string[] = [
   "get-host-context",
   "get-host-version",
 ];
-const cliTargetIndex = process.argv.indexOf("--target");
-const cliTarget = cliTargetIndex !== -1 ? process.argv[cliTargetIndex + 1] : null;
-if (cliTarget) {
+
+function cliTargets(argv: string[]): string[] {
+  const values: string[] = [];
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+
+    if (arg === "--target" || arg === "--targets") {
+      const value = argv[i + 1];
+      if (value) {
+        values.push(value);
+        i += 1;
+      }
+      continue;
+    }
+
+    if (arg.startsWith("--target=") || arg.startsWith("--targets=")) {
+      values.push(arg.slice(arg.indexOf("=") + 1));
+    }
+  }
+
+  return values.flatMap((value) =>
+    value
+      .split(",")
+      .map((target) => target.trim())
+      .filter(Boolean)
+  );
+}
+
+const requestedTargets = cliTargets(process.argv.slice(2));
+if (requestedTargets.length) {
   targets.length = 0;
-  targets.push(cliTarget);
+  targets.push(...requestedTargets);
 }
 
 const builtNames: string[] = [];
@@ -164,16 +191,27 @@ for (const file of entries) {
 }
 
 const outputs = fs
-  .readdirSync("assets")
+  .readdirSync(outDir)
   .filter((f) => f.endsWith(".js") || f.endsWith(".css"))
-  .map((f) => path.join("assets", f))
+  .sort()
+  .map((f) => path.join(outDir, f))
   .filter((p) => fs.existsSync(p));
 
-const h = crypto
-  .createHash("sha256")
-  .update(pkg.version, "utf8")
-  .digest("hex")
-  .slice(0, 4);
+const outputHash = crypto.createHash("sha256");
+for (const out of outputs) {
+  outputHash.update(path.basename(out), "utf8");
+  outputHash.update("\0", "utf8");
+  outputHash.update(fs.readFileSync(out));
+  outputHash.update("\0", "utf8");
+}
+const assetHashSalt = (process.env.ASSET_HASH_SALT ?? "").trim();
+if (assetHashSalt) {
+  outputHash.update("ASSET_HASH_SALT", "utf8");
+  outputHash.update("\0", "utf8");
+  outputHash.update(assetHashSalt, "utf8");
+  outputHash.update("\0", "utf8");
+}
+const h = outputHash.digest("hex").slice(0, 8);
 
 console.group("Hashing outputs");
 for (const out of outputs) {
@@ -188,16 +226,9 @@ for (const out of outputs) {
 console.groupEnd();
 
 console.log("new hash: ", h);
-
-const defaultBaseUrl = "http://localhost:4444";
-const baseUrlCandidate = (
-  process.env.VITE_BASE_URL ??
-  process.env.BASE_URL ??
-  ""
-).trim();
-const baseUrlRaw = baseUrlCandidate.length > 0 ? baseUrlCandidate : defaultBaseUrl;
-const normalizedBaseUrl = baseUrlRaw.replace(/\/+$/, "") || defaultBaseUrl;
-console.log(`Using BASE_URL ${normalizedBaseUrl} for generated HTML`);
+if (assetHashSalt) {
+  console.log("Using ASSET_HASH_SALT for generated asset URLs");
+}
 
 const defaultApiBaseUrl = "http://localhost:8000";
 const apiBaseUrlCandidate = (
@@ -209,10 +240,20 @@ const apiBaseUrlRaw =
   apiBaseUrlCandidate.length > 0 ? apiBaseUrlCandidate : defaultApiBaseUrl;
 const normalizedApiBaseUrl =
   apiBaseUrlRaw.replace(/\/+$/, "") || defaultApiBaseUrl;
+const defaultBaseUrl = `${normalizedApiBaseUrl}/assets`;
+const baseUrlCandidate = (
+  process.env.VITE_BASE_URL ??
+  process.env.BASE_URL ??
+  ""
+).trim();
+const baseUrlRaw =
+  baseUrlCandidate.length > 0 ? baseUrlCandidate : defaultBaseUrl;
+const normalizedBaseUrl = baseUrlRaw.replace(/\/+$/, "") || defaultBaseUrl;
 const appUrlConfigJson = JSON.stringify({
   apiBaseUrl: normalizedApiBaseUrl,
   assetsBaseUrl: normalizedBaseUrl,
 });
+console.log(`Using BASE_URL ${normalizedBaseUrl} for generated HTML`);
 console.log(`Using API_BASE_URL ${normalizedApiBaseUrl} for generated HTML`);
 
 for (const name of builtNames) {

--- a/mcp_app_basics_node/README.md
+++ b/mcp_app_basics_node/README.md
@@ -5,7 +5,7 @@ Educational MCP server with eleven interactive examples covering the core MCP Ap
 ## Prerequisites
 
 - Node 18+
-- Static assets built (`pnpm run build` from repo root)
+- Dependencies installed (`pnpm install` from repo root)
 
 ## Install & run
 
@@ -15,7 +15,26 @@ pnpm start
 # or change port: PORT=9000 pnpm start
 ```
 
-Server listens on `http://localhost:8000/mcp`.
+`pnpm start` builds the eleven basics widgets first, then starts the MCP server.
+The basics build script adds a fresh `ASSET_HASH_SALT` each run so ChatGPT and
+browser caches see new JS/CSS asset URLs. To only rebuild those widgets, run:
+
+```bash
+pnpm run build:widgets
+```
+
+Server listens on `http://localhost:8000/mcp` and serves built widget assets from
+`http://localhost:8000/assets`. It binds to `127.0.0.1` by default; set
+`HOST=0.0.0.0` only if you need LAN access. When testing through ngrok, expose
+this server once; resource HTML infers the public origin from the incoming
+request headers so the same tunnel serves both `/mcp` and `/assets`. Set
+`PUBLIC_BASE_URL` or `API_BASE_URL` only if you need to override that inferred
+origin.
+
+For ChatGPT, widget resources declare both `_meta.ui.csp` and
+`openai/widgetCSP`, allowlisting the same public origin used for `/mcp` and
+`/assets`. If ngrok or another proxy does not forward the expected public host,
+set `PUBLIC_BASE_URL=https://your-public-origin` when starting the server.
 
 ## Examples
 
@@ -24,21 +43,21 @@ Server listens on `http://localhost:8000/mcp`.
 | Tool | API | Try saying in ChatGPT |
 |------|-----|-----------------------|
 | `show_tool_result` | `ontoolresult` + `structuredContent` | "Show me how a tool result gets displayed in a widget" |
-| `send_message` | `app.sendMessage()` | "How do I send a message from a widget?" |
+| `send_message` | `window.openai.sendFollowUpMessage()` | "How do I send a message from a widget?" |
 | `update_model_context` | `app.updateModelContext()` | "How can a widget silently give context to the model?" |
 
 ### Widget ↔ Server
 
 | Tool | API | Try saying in ChatGPT |
 |------|-----|-----------------------|
-| `call_server_tool` | `app.callServerTool()` | "Show me how a widget calls a server tool directly" |
+| `call_server_tool` | `window.openai.callTool()` | "Show me how a widget calls a server tool directly" |
 
 ### Host Interaction
 
 | Tool | API | Try saying in ChatGPT |
 |------|-----|-----------------------|
-| `open_link` | `app.openLink()` | "How do I open a link from a widget?" |
-| `request_display_mode` | `app.requestDisplayMode()` + `getHostContext()` | "How do I make a widget go fullscreen?" |
+| `open_link` | `window.openai.openExternal()` | "How do I open a link from a widget?" |
+| `request_display_mode` | `window.openai.requestDisplayMode()` + host globals | "How do I make a widget go fullscreen?" |
 | `host_theming` | `useHostStyles()` + `useDocumentTheme()` | "How do I match the host's theme in my widget?" |
 | `get_host_capabilities` | `app.getHostCapabilities()` | "How do I check what the host supports?" |
 | `get_host_context` | `app.getHostContext()` + `onhostcontextchanged` | "How do I get the host's theme and locale?" |

--- a/mcp_app_basics_node/package.json
+++ b/mcp_app_basics_node/package.json
@@ -5,7 +5,9 @@
   "private": true,
   "description": "Minimal MCP App server that demonstrates registerAppTool and registerAppResource.",
   "scripts": {
-    "start": "tsx src/server.ts"
+    "build:widgets": "sh ./scripts/build-widgets.sh",
+    "server:start": "node --import tsx src/server.ts",
+    "start": "sh ./scripts/start.sh"
   },
   "dependencies": {
     "@modelcontextprotocol/ext-apps": "^1.0.1",

--- a/mcp_app_basics_node/scripts/build-widgets.sh
+++ b/mcp_app_basics_node/scripts/build-widgets.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+set -eu
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+SERVER_DIR=$(cd "$SCRIPT_DIR/.." && pwd)
+ROOT_DIR=$(cd "$SERVER_DIR/.." && pwd)
+
+TARGETS="show-tool-result,send-message,update-model-context,call-server-tool,host-theming,open-link,request-display-mode,streaming-tool-input,get-host-capabilities,get-host-context,get-host-version"
+ASSET_HASH_SALT=${ASSET_HASH_SALT:-"$(date +%Y%m%d%H%M%S)-$$"}
+
+cd "$ROOT_DIR"
+ASSET_HASH_SALT="$ASSET_HASH_SALT" pnpm run build -- --target "$TARGETS"

--- a/mcp_app_basics_node/scripts/start.sh
+++ b/mcp_app_basics_node/scripts/start.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+set -eu
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+SERVER_DIR=$(cd "$SCRIPT_DIR/.." && pwd)
+
+sh "$SCRIPT_DIR/build-widgets.sh"
+
+cd "$SERVER_DIR"
+exec node --import tsx src/server.ts

--- a/mcp_app_basics_node/src/server.ts
+++ b/mcp_app_basics_node/src/server.ts
@@ -3,12 +3,12 @@
  *
  * Educational demo server with eleven tools:
  *   - show_tool_result: data flowing IN to a widget (structuredContent)
- *   - send_message: data flowing OUT from a widget (app.sendMessage)
+ *   - send_message: data flowing OUT from a widget (window.openai.sendFollowUpMessage)
  *   - update_model_context: silent context injection (app.updateModelContext)
- *   - call_server_tool: widget calling server tools directly (app.callServerTool)
+ *   - call_server_tool: widget calling server tools directly (window.openai.callTool)
  *   - host_theming: adapting to host theme (useHostStyles + useDocumentTheme)
- *   - open_link: opening external URLs via app.openLink()
- *   - request_display_mode: changing widget display mode via app.requestDisplayMode()
+ *   - open_link: opening external URLs via window.openai.openExternal()
+ *   - request_display_mode: changing widget display mode via window.openai.requestDisplayMode()
  *   - streaming_tool_input: streaming partial tool input via app.ontoolinputpartial
  *   - get_host_capabilities: querying host capabilities via app.getHostCapabilities()
  *   - get_host_context: querying host context via app.getHostContext()
@@ -28,6 +28,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import cors from "cors";
 import express from "express";
+import type { Request } from "express";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -38,6 +39,8 @@ const SERVER_VERSION = "0.1.3";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT_DIR = path.resolve(__dirname, "..", "..");
 const ASSETS_DIR = path.resolve(ROOT_DIR, "assets");
+const port = parseInt(process.env.PORT ?? "8000", 10);
+const host = process.env.HOST ?? "127.0.0.1";
 
 const SHOW_TOOL_RESULT_URI = "ui://show-tool-result/show-tool-result.html";
 const SEND_MESSAGE_URI = "ui://send-message/send-message.html";
@@ -57,7 +60,107 @@ const GET_HOST_CONTEXT_URI =
   "ui://get-host-context/get-host-context.html";
 const GET_HOST_VERSION_URI =
   "ui://get-host-version/get-host-version.html";
-function readWidgetHtml(widgetName: string): string {
+
+function normalizedBaseUrl(value: string): string {
+  return value.trim().replace(/\/+$/, "");
+}
+
+function normalizedOrigin(value: string): string {
+  const normalized = normalizedBaseUrl(value);
+
+  try {
+    return new URL(normalized).origin;
+  } catch {
+    return normalized;
+  }
+}
+
+function firstNonEmpty(...values: Array<string | undefined>): string | undefined {
+  return values.find((value) => Boolean(value?.trim()));
+}
+
+const configuredPublicBaseUrl = firstNonEmpty(
+  process.env.PUBLIC_BASE_URL,
+  process.env.APP_BASE_URL,
+  process.env.VITE_API_BASE_URL,
+  process.env.API_BASE_URL,
+  process.env.VITE_BASE_URL,
+  process.env.BASE_URL
+);
+
+function firstHeaderValue(
+  value: string | string[] | undefined
+): string | undefined {
+  if (Array.isArray(value)) return value[0];
+  return value;
+}
+
+function firstHeaderToken(
+  value: string | string[] | undefined
+): string | undefined {
+  return firstHeaderValue(value)?.split(",")[0]?.trim();
+}
+
+function publicBaseUrlForRequest(req: Request): string {
+  if (configuredPublicBaseUrl) return normalizedOrigin(configuredPublicBaseUrl);
+
+  const host =
+    firstHeaderToken(req.headers["x-forwarded-host"]) ??
+    firstHeaderToken(req.headers.host) ??
+    `localhost:${port}`;
+  const protocol =
+    firstHeaderToken(req.headers["x-forwarded-proto"]) ??
+    req.protocol ??
+    "http";
+
+  return normalizedOrigin(`${protocol}://${host}`);
+}
+
+function rewriteWidgetHtml(html: string, publicBaseUrl: string): string {
+  const widgetAssetsBaseUrl = `${publicBaseUrl}/assets`;
+
+  return html
+    .replaceAll("http://localhost:4444", widgetAssetsBaseUrl)
+    .replaceAll("http://127.0.0.1:4444", widgetAssetsBaseUrl)
+    .replaceAll("http://localhost:8000", publicBaseUrl)
+    .replaceAll("http://127.0.0.1:8000", publicBaseUrl)
+    .replace(
+      /\n?\s*<script>\s*window\.__APP_URL_CONFIG__\s*=\s*\{[^<]*\};\s*<\/script>\s*/u,
+      "\n"
+    );
+}
+
+function widgetResourceContent(
+  uri: string,
+  text: string,
+  description: string,
+  publicBaseUrl: string
+) {
+  const allowedDomains = [publicBaseUrl];
+
+  return {
+    uri,
+    mimeType: RESOURCE_MIME_TYPE,
+    text,
+    _meta: {
+      "openai/widgetDescription": description,
+      "openai/widgetPrefersBorder": true,
+      "openai/widgetCSP": {
+        connect_domains: allowedDomains,
+        resource_domains: allowedDomains,
+      },
+      ui: {
+        prefersBorder: true,
+        csp: {
+          connectDomains: allowedDomains,
+          resourceDomains: allowedDomains,
+        },
+      },
+    },
+  };
+}
+
+function readWidgetHtml(widgetName: string, publicBaseUrl: string): string {
   if (!fs.existsSync(ASSETS_DIR)) {
     throw new Error(
       `Widget assets not found. Expected directory ${ASSETS_DIR}. Run "pnpm run build" before starting the server.`
@@ -67,7 +170,7 @@ function readWidgetHtml(widgetName: string): string {
   const directPath = path.join(ASSETS_DIR, `${widgetName}.html`);
 
   if (fs.existsSync(directPath)) {
-    return fs.readFileSync(directPath, "utf8");
+    return rewriteWidgetHtml(fs.readFileSync(directPath, "utf8"), publicBaseUrl);
   }
 
   // Fall back to hashed filename: {widgetName}-{hash}.html
@@ -80,7 +183,10 @@ function readWidgetHtml(widgetName: string): string {
   const fallback = candidates[candidates.length - 1];
 
   if (fallback) {
-    return fs.readFileSync(path.join(ASSETS_DIR, fallback), "utf8");
+    return rewriteWidgetHtml(
+      fs.readFileSync(path.join(ASSETS_DIR, fallback), "utf8"),
+      publicBaseUrl
+    );
   }
 
   throw new Error(
@@ -88,18 +194,10 @@ function readWidgetHtml(widgetName: string): string {
   );
 }
 
-const showToolResultHtml = readWidgetHtml("show-tool-result");
-const sendMessageHtml = readWidgetHtml("send-message");
-const updateModelContextHtml = readWidgetHtml("update-model-context");
-const callServerToolHtml = readWidgetHtml("call-server-tool");
-const hostThemingHtml = readWidgetHtml("host-theming");
-const openLinkHtml = readWidgetHtml("open-link");
-const requestDisplayModeHtml = readWidgetHtml("request-display-mode");
-const streamingToolInputHtml = readWidgetHtml("streaming-tool-input");
-const getHostCapabilitiesHtml = readWidgetHtml("get-host-capabilities");
-const getHostContextHtml = readWidgetHtml("get-host-context");
-const getHostVersionHtml = readWidgetHtml("get-host-version");
-function createServer(): McpServer {
+function createServer(publicBaseUrl: string): McpServer {
+  const widgetHtml = (widgetName: string) =>
+    readWidgetHtml(widgetName, publicBaseUrl);
+
   const server = new McpServer({
     name: "mcp-app-basics",
     version: SERVER_VERSION,
@@ -127,7 +225,10 @@ function createServer(): McpServer {
         destructiveHint: false,
         openWorldHint: false,
       },
-      _meta: { ui: { resourceUri: SHOW_TOOL_RESULT_URI } },
+      _meta: {
+        ui: { resourceUri: SHOW_TOOL_RESULT_URI },
+        "openai/outputTemplate": SHOW_TOOL_RESULT_URI,
+      },
     },
     async ({ name }) => {
       const resolvedName = name ?? "World";
@@ -193,7 +294,12 @@ function createServer(): McpServer {
                 `  "${SHOW_TOOL_RESULT_URI}",`,
                 `  { mimeType: RESOURCE_MIME_TYPE },`,
                 `  async () => ({`,
-                `    contents: [{ uri, mimeType, text: widgetHtml }],`,
+                `    contents: [{`,
+                `      uri: "${SHOW_TOOL_RESULT_URI}",`,
+                `      mimeType: RESOURCE_MIME_TYPE,`,
+                `      text: widgetHtml,`,
+                `      _meta: { ui: { prefersBorder: true } },`,
+                `    }],`,
                 `  })`,
                 `);`,
               ].join("\n"),
@@ -201,17 +307,14 @@ function createServer(): McpServer {
             {
               id: 4,
               title: "Widget receives data",
-              summary: "useApp() from @modelcontextprotocol/ext-apps/react",
+              summary:
+                "Read structuredContent through window.openai.toolOutput or a small useOpenAiGlobal helper",
               code: [
-                `import { useApp } from "@modelcontextprotocol/ext-apps/react";`,
+                `import { useOpenAiGlobal } from "./use-openai-global";`,
                 ``,
-                `const { app } = useApp({`,
-                `  onAppCreated: (app) => {`,
-                `    app.ontoolresult = (result) => {`,
-                `      setData(result.structuredContent);`,
-                `    };`,
-                `  },`,
-                `});`,
+                `const toolOutput = useOpenAiGlobal("toolOutput");`,
+                `// toolOutput is the tool result's structuredContent.`,
+                `// The model can also read this data, so keep it concise.`,
               ].join("\n"),
             },
             {
@@ -237,7 +340,7 @@ function createServer(): McpServer {
       title: "Send Message",
       description:
         "Demonstrates how a widget sends a message into the conversation on behalf of the user " +
-        "using app.sendMessage(). The message triggers a model response, enabling bidirectional " +
+        "using window.openai.sendFollowUpMessage(). The message triggers a model response, enabling bidirectional " +
         "widget-to-model communication. Use when the user asks how to send a message from a widget, " +
         "have a widget chat or talk to the AI, trigger a follow-up model response from a component, " +
         "or enable two-way communication between a widget and the model.",
@@ -247,7 +350,10 @@ function createServer(): McpServer {
         destructiveHint: false,
         openWorldHint: false,
       },
-      _meta: { ui: { resourceUri: SEND_MESSAGE_URI } },
+      _meta: {
+        ui: { resourceUri: SEND_MESSAGE_URI },
+        "openai/outputTemplate": SEND_MESSAGE_URI,
+      },
     },
     async () => {
       return {
@@ -256,8 +362,8 @@ function createServer(): McpServer {
             type: "text" as const,
             text: [
               'The "send_message" tool was called.',
-              "A live widget is now ready for the user to type a message and send it into the conversation via app.sendMessage().",
-              "Explain how sendMessage enables widget-to-model communication, tailored to the user's question.",
+              "A live widget is now ready for the user to type a message and send it into the conversation via window.openai.sendFollowUpMessage().",
+              "Explain how sendFollowUpMessage enables widget-to-model communication, tailored to the user's question.",
               "Encourage follow-up questions about MCP Apps.",
             ].join(" "),
           },
@@ -293,26 +399,29 @@ function createServer(): McpServer {
             },
             {
               id: 3,
-              title: "Call app.sendMessage()",
+              title: "Call window.openai.sendFollowUpMessage()",
               summary:
-                'Send a user-role message that appears in the conversation and triggers a model response',
+                "Ask ChatGPT to post a component-authored follow-up message and trigger a model response",
               code: [
-                `const result = await app.sendMessage({`,
-                `  role: "user",`,
-                `  content: [{ type: "text", text: "Hello from the widget!" }],`,
+                `await window.openai.sendFollowUpMessage({`,
+                `  prompt: "Hello from the widget!",`,
+                `  scrollToBottom: true,`,
                 `});`,
               ].join("\n"),
             },
             {
               id: 4,
-              title: "Handle the result",
+              title: "Fallback for broader MCP Apps hosts",
               summary:
-                "Check result.isError; on success the message appears in the chat and the model responds",
+                "If the ChatGPT extension is unavailable, fall back to the MCP Apps bridge helper",
               code: [
-                `if (result.isError) {`,
-                `  // handle error`,
+                `if (window.openai?.sendFollowUpMessage) {`,
+                `  await window.openai.sendFollowUpMessage({ prompt });`,
                 `} else {`,
-                `  // message sent successfully`,
+                `  await app.sendMessage({`,
+                `    role: "user",`,
+                `    content: [{ type: "text", text: prompt }],`,
+                `  });`,
                 `}`,
               ].join("\n"),
             },
@@ -341,7 +450,10 @@ function createServer(): McpServer {
         destructiveHint: false,
         openWorldHint: false,
       },
-      _meta: { ui: { resourceUri: UPDATE_MODEL_CONTEXT_URI } },
+      _meta: {
+        ui: { resourceUri: UPDATE_MODEL_CONTEXT_URI },
+        "openai/outputTemplate": UPDATE_MODEL_CONTEXT_URI,
+      },
     },
     async () => {
       return {
@@ -351,7 +463,7 @@ function createServer(): McpServer {
             text: [
               'The "update_model_context" tool was called.',
               "A live widget is now ready for the user to set context that will be silently included in the model's next turn via app.updateModelContext().",
-              "Explain how updateModelContext differs from sendMessage: it is deferred (not immediate) and does not trigger a model response on its own.",
+              "Explain how updateModelContext differs from sendFollowUpMessage: it is deferred (not immediate) and does not trigger a model response on its own.",
               "Encourage follow-up questions about MCP Apps.",
             ].join(" "),
           },
@@ -400,7 +512,7 @@ function createServer(): McpServer {
               id: 4,
               title: "Deferred, last-write-wins",
               summary:
-                "Each call overwrites the previous; context is delivered on the next user message or sendMessage turn",
+                "Each call overwrites the previous; context is delivered on the next user message or follow-up turn",
               code: [
                 `// First call sets context`,
                 `await app.updateModelContext({`,
@@ -427,17 +539,20 @@ function createServer(): McpServer {
     {
       title: "Call Server Tool",
       description:
-        "Demonstrates how a widget calls a server tool directly via app.callServerTool(), " +
+        "Demonstrates how a widget calls a server tool directly via window.openai.callTool(), " +
         "bypassing the model entirely. The widget calls an app-only dice-roll tool registered " +
         'with visibility: ["app"]. Use when the user asks how to call a tool from a widget, ' +
-        "invoke server-side logic from a component, use callServerTool, or create app-only tools.",
+        "invoke server-side logic from a component, use callTool, or create app-only tools.",
       inputSchema: {},
       annotations: {
         readOnlyHint: true,
         destructiveHint: false,
         openWorldHint: false,
       },
-      _meta: { ui: { resourceUri: CALL_SERVER_TOOL_URI } },
+      _meta: {
+        ui: { resourceUri: CALL_SERVER_TOOL_URI },
+        "openai/outputTemplate": CALL_SERVER_TOOL_URI,
+      },
     },
     async () => {
       return {
@@ -446,8 +561,8 @@ function createServer(): McpServer {
             type: "text" as const,
             text: [
               'The "call_server_tool" tool was called.',
-              "A live widget is now ready for the user to roll dice by calling an app-only server tool directly via app.callServerTool().",
-              "Explain how callServerTool enables widget-to-server communication without model involvement, tailored to the user's question.",
+              "A live widget is now ready for the user to roll dice by calling an app-only server tool directly via window.openai.callTool().",
+              "Explain how callTool enables widget-to-server communication without model involvement, tailored to the user's question.",
               "Encourage follow-up questions about MCP Apps.",
             ].join(" "),
           },
@@ -475,18 +590,12 @@ function createServer(): McpServer {
               id: 2,
               title: "Widget calls the tool",
               summary:
-                "app.callServerTool() sends a request to the server, proxied by the host",
+                "window.openai.callTool() sends a request to the server, proxied by the host",
               code: [
-                `const { app } = useApp({`,
-                `  onAppCreated: (app) => {`,
-                `    app.ontoolresult = () => setReady(true);`,
-                `  },`,
-                `});`,
-                ``,
-                `const result = await app.callServerTool({`,
-                `  name: "call_server_tool__roll_dice",`,
-                `  arguments: { sides: 20 },`,
-                `});`,
+                `const result = await window.openai.callTool(`,
+                `  "call_server_tool__roll_dice",`,
+                `  { sides: 20 }`,
+                `);`,
               ].join("\n"),
             },
             {
@@ -498,7 +607,8 @@ function createServer(): McpServer {
                 `if (result.isError) {`,
                 `  console.error("Tool error:", result.content);`,
                 `} else {`,
-                `  const data = JSON.parse(result.content[0].text);`,
+                `  const data = result.structuredContent`,
+                `    ?? JSON.parse(result.content[0].text);`,
                 `  console.log("Rolled:", data.rolled);`,
                 `}`,
               ].join("\n"),
@@ -514,6 +624,9 @@ function createServer(): McpServer {
                 ``,
                 `// App-only tool (hidden from model):`,
                 `//   _meta: { ui: { visibility: ["app"] } }`,
+                ``,
+                `// For broader MCP Apps hosts, fall back to:`,
+                `// app.callServerTool({ name, arguments })`,
               ].join("\n"),
             },
           ],
@@ -570,7 +683,10 @@ function createServer(): McpServer {
         destructiveHint: false,
         openWorldHint: false,
       },
-      _meta: { ui: { resourceUri: HOST_THEMING_URI } },
+      _meta: {
+        ui: { resourceUri: HOST_THEMING_URI },
+        "openai/outputTemplate": HOST_THEMING_URI,
+      },
     },
     async () => {
       return {
@@ -672,11 +788,12 @@ function createServer(): McpServer {
     },
     async () => ({
       contents: [
-        {
-          uri: SHOW_TOOL_RESULT_URI,
-          mimeType: RESOURCE_MIME_TYPE,
-          text: showToolResultHtml,
-        },
+        widgetResourceContent(
+          SHOW_TOOL_RESULT_URI,
+          widgetHtml("show-tool-result"),
+          "Displays structuredContent from an MCP tool result.",
+          publicBaseUrl
+        ),
       ],
     })
   );
@@ -688,11 +805,12 @@ function createServer(): McpServer {
     { mimeType: RESOURCE_MIME_TYPE, description: "Send Message widget HTML" },
     async () => ({
       contents: [
-        {
-          uri: SEND_MESSAGE_URI,
-          mimeType: RESOURCE_MIME_TYPE,
-          text: sendMessageHtml,
-        },
+        widgetResourceContent(
+          SEND_MESSAGE_URI,
+          widgetHtml("send-message"),
+          "Sends a component-authored follow-up message to ChatGPT.",
+          publicBaseUrl
+        ),
       ],
     })
   );
@@ -707,11 +825,12 @@ function createServer(): McpServer {
     },
     async () => ({
       contents: [
-        {
-          uri: UPDATE_MODEL_CONTEXT_URI,
-          mimeType: RESOURCE_MIME_TYPE,
-          text: updateModelContextHtml,
-        },
+        widgetResourceContent(
+          UPDATE_MODEL_CONTEXT_URI,
+          widgetHtml("update-model-context"),
+          "Updates model context quietly for a future model turn.",
+          publicBaseUrl
+        ),
       ],
     })
   );
@@ -726,11 +845,12 @@ function createServer(): McpServer {
     },
     async () => ({
       contents: [
-        {
-          uri: CALL_SERVER_TOOL_URI,
-          mimeType: RESOURCE_MIME_TYPE,
-          text: callServerToolHtml,
-        },
+        widgetResourceContent(
+          CALL_SERVER_TOOL_URI,
+          widgetHtml("call-server-tool"),
+          "Calls an app-only MCP server tool directly from the widget.",
+          publicBaseUrl
+        ),
       ],
     })
   );
@@ -745,11 +865,12 @@ function createServer(): McpServer {
     },
     async () => ({
       contents: [
-        {
-          uri: HOST_THEMING_URI,
-          mimeType: RESOURCE_MIME_TYPE,
-          text: hostThemingHtml,
-        },
+        widgetResourceContent(
+          HOST_THEMING_URI,
+          widgetHtml("host-theming"),
+          "Shows host theme variables and Apps SDK UI token styling.",
+          publicBaseUrl
+        ),
       ],
     })
   );
@@ -761,7 +882,7 @@ function createServer(): McpServer {
     {
       title: "Open Link",
       description:
-        "Demonstrates how a widget opens an external URL via app.openLink(). The host may deny " +
+        "Demonstrates how a widget opens an external URL via window.openai.openExternal(). The host may deny " +
         "the request based on its security policy. Use when the user asks how to open a link from " +
         "a widget, navigate to an external URL, launch a browser tab, or handle link denial.",
       inputSchema: {},
@@ -770,7 +891,10 @@ function createServer(): McpServer {
         destructiveHint: false,
         openWorldHint: false,
       },
-      _meta: { ui: { resourceUri: OPEN_LINK_URI } },
+      _meta: {
+        ui: { resourceUri: OPEN_LINK_URI },
+        "openai/outputTemplate": OPEN_LINK_URI,
+      },
     },
     async () => {
       return {
@@ -779,8 +903,8 @@ function createServer(): McpServer {
             type: "text" as const,
             text: [
               'The "open_link" tool was called.',
-              "A live widget is now ready for the user to open links via app.openLink().",
-              "Explain how openLink requests the host to open a URL, and how the host may deny the request based on its security policy.",
+              "A live widget is now ready for the user to open links via window.openai.openExternal().",
+              "Explain how openExternal requests the host to open a URL, and how the host may deny the request based on its security policy.",
               "Encourage follow-up questions about MCP Apps.",
             ].join(" "),
           },
@@ -803,18 +927,12 @@ function createServer(): McpServer {
             },
             {
               id: 2,
-              title: "Call app.openLink()",
+              title: "Call window.openai.openExternal()",
               summary:
                 "Request the host to open a URL in a new tab or browser",
               code: [
-                `const { app } = useApp({`,
-                `  onAppCreated: (app) => {`,
-                `    app.ontoolresult = () => setReady(true);`,
-                `  },`,
-                `});`,
-                ``,
-                `const result = await app.openLink({`,
-                `  url: "https://example.com",`,
+                `await window.openai.openExternal({`,
+                `  href: "https://example.com",`,
                 `});`,
               ].join("\n"),
             },
@@ -822,14 +940,15 @@ function createServer(): McpServer {
               id: 3,
               title: "Handle denial",
               summary:
-                "The host may deny the request based on its security policy — check isError",
+                "The host may deny the request based on its security policy; keep a fallback for broader MCP Apps hosts",
               code: [
-                `if (result.isError) {`,
-                `  // Host denied the request`,
-                `  console.log("Link denied by host");`,
+                `if (window.openai?.openExternal) {`,
+                `  await window.openai.openExternal({ href });`,
                 `} else {`,
-                `  // Link opened successfully`,
-                `  console.log("Link opened");`,
+                `  const result = await app.openLink({ url: href });`,
+                `  if (result.isError) {`,
+                `    console.log("Link denied by host");`,
+                `  }`,
                 `}`,
               ].join("\n"),
             },
@@ -860,11 +979,12 @@ function createServer(): McpServer {
     },
     async () => ({
       contents: [
-        {
-          uri: OPEN_LINK_URI,
-          mimeType: RESOURCE_MIME_TYPE,
-          text: openLinkHtml,
-        },
+        widgetResourceContent(
+          OPEN_LINK_URI,
+          widgetHtml("open-link"),
+          "Requests host-mediated navigation to external URLs.",
+          publicBaseUrl
+        ),
       ],
     })
   );
@@ -876,7 +996,7 @@ function createServer(): McpServer {
     {
       title: "Request Display Mode",
       description:
-        "Demonstrates how a widget changes its display mode via app.requestDisplayMode(). " +
+        "Demonstrates how a widget changes its display mode via window.openai.requestDisplayMode(). " +
         "Supports inline, fullscreen, and pip modes. The host may grant a different mode than " +
         "requested. Use when the user asks how to go fullscreen, change widget size, use picture-in-picture, " +
         "request display mode, or check available display modes.",
@@ -886,7 +1006,10 @@ function createServer(): McpServer {
         destructiveHint: false,
         openWorldHint: false,
       },
-      _meta: { ui: { resourceUri: REQUEST_DISPLAY_MODE_URI } },
+      _meta: {
+        ui: { resourceUri: REQUEST_DISPLAY_MODE_URI },
+        "openai/outputTemplate": REQUEST_DISPLAY_MODE_URI,
+      },
     },
     async () => {
       return {
@@ -895,7 +1018,7 @@ function createServer(): McpServer {
             type: "text" as const,
             text: [
               'The "request_display_mode" tool was called.',
-              "A live widget is now ready for the user to switch between inline, fullscreen, and pip display modes via app.requestDisplayMode().",
+              "A live widget is now ready for the user to switch between inline, fullscreen, and pip display modes via window.openai.requestDisplayMode().",
               "Explain how requestDisplayMode works, that it must be called from a user-initiated action, and that the host may grant a different mode than requested.",
               "Encourage follow-up questions about MCP Apps.",
             ].join(" "),
@@ -921,16 +1044,12 @@ function createServer(): McpServer {
               id: 2,
               title: "Check available modes",
               summary:
-                "Use getHostContext() to see which modes the host supports",
+                "Read ChatGPT globals, and fall back to host context when a broader MCP Apps host exposes available modes",
               code: [
-                `const { app } = useApp({`,
-                `  onAppCreated: (app) => {`,
-                `    app.ontoolresult = () => setReady(true);`,
-                `  },`,
-                `});`,
-                ``,
-                `const ctx = app.getHostContext();`,
-                `const available = ctx?.availableDisplayModes;`,
+                `const mode = window.openai.displayMode;`,
+                `const view = window.openai.view;`,
+                `// For broader MCP Apps hosts, app.getHostContext()`,
+                `// may include availableDisplayModes.`,
                 `// e.g. ["inline", "fullscreen", "pip"]`,
               ].join("\n"),
             },
@@ -941,7 +1060,7 @@ function createServer(): McpServer {
                 "Must be called from a user-initiated action (button click) — will fail if called programmatically",
               code: [
                 `// IMPORTANT: Must be in a click handler!`,
-                `const result = await app.requestDisplayMode({`,
+                `const result = await window.openai.requestDisplayMode({`,
                 `  mode: "fullscreen",`,
                 `});`,
                 `console.log("Granted:", result.mode);`,
@@ -953,7 +1072,7 @@ function createServer(): McpServer {
               summary:
                 "The host may grant a different mode — always check the result",
               code: [
-                `const result = await app.requestDisplayMode({`,
+                `const result = await window.openai.requestDisplayMode({`,
                 `  mode: "pip",`,
                 `});`,
                 ``,
@@ -965,14 +1084,17 @@ function createServer(): McpServer {
             },
             {
               id: 5,
-              title: "Listen for context changes",
+              title: "React to host global changes",
               summary:
-                "onhostcontextchanged fires when the display mode changes (including user-initiated changes)",
+                "Subscribe to openai:set_globals or use a helper such as useOpenAiGlobal",
               code: [
-                `app.onhostcontextchanged = (ctx) => {`,
-                `  console.log("New mode:", ctx.displayMode);`,
-                `  console.log("Available:", ctx.availableDisplayModes);`,
-                `};`,
+                `function useDisplayMode() {`,
+                `  return useOpenAiGlobal("displayMode");`,
+                `}`,
+                ``,
+                `window.addEventListener("openai:set_globals", (event) => {`,
+                `  console.log(event.detail.globals.displayMode);`,
+                `});`,
               ].join("\n"),
             },
           ],
@@ -991,11 +1113,12 @@ function createServer(): McpServer {
     },
     async () => ({
       contents: [
-        {
-          uri: REQUEST_DISPLAY_MODE_URI,
-          mimeType: RESOURCE_MIME_TYPE,
-          text: requestDisplayModeHtml,
-        },
+        widgetResourceContent(
+          REQUEST_DISPLAY_MODE_URI,
+          widgetHtml("request-display-mode"),
+          "Requests inline, fullscreen, or picture-in-picture display modes.",
+          publicBaseUrl
+        ),
       ],
     })
   );
@@ -1038,7 +1161,10 @@ function createServer(): McpServer {
         destructiveHint: false,
         openWorldHint: false,
       },
-      _meta: { ui: { resourceUri: STREAMING_TOOL_INPUT_URI } },
+      _meta: {
+        ui: { resourceUri: STREAMING_TOOL_INPUT_URI },
+        "openai/outputTemplate": STREAMING_TOOL_INPUT_URI,
+      },
     },
     async ({ title, author }) => {
       return {
@@ -1145,11 +1271,12 @@ function createServer(): McpServer {
     },
     async () => ({
       contents: [
-        {
-          uri: STREAMING_TOOL_INPUT_URI,
-          mimeType: RESOURCE_MIME_TYPE,
-          text: streamingToolInputHtml,
-        },
+        widgetResourceContent(
+          STREAMING_TOOL_INPUT_URI,
+          widgetHtml("streaming-tool-input"),
+          "Previews streamed tool arguments before the final tool result.",
+          publicBaseUrl
+        ),
       ],
     })
   );
@@ -1171,7 +1298,10 @@ function createServer(): McpServer {
         destructiveHint: false,
         openWorldHint: false,
       },
-      _meta: { ui: { resourceUri: GET_HOST_CAPABILITIES_URI } },
+      _meta: {
+        ui: { resourceUri: GET_HOST_CAPABILITIES_URI },
+        "openai/outputTemplate": GET_HOST_CAPABILITIES_URI,
+      },
     },
     async () => {
       return {
@@ -1227,7 +1357,7 @@ function createServer(): McpServer {
                 "Each field is present if supported, undefined if not",
               code: [
                 `if (caps.openLinks) {`,
-                `  // Safe to call app.openLink()`,
+                `  // Safe to call window.openai.openExternal()`,
                 `}`,
                 `if (caps.updateModelContext) {`,
                 `  // Safe to call app.updateModelContext()`,
@@ -1261,11 +1391,12 @@ function createServer(): McpServer {
     },
     async () => ({
       contents: [
-        {
-          uri: GET_HOST_CAPABILITIES_URI,
-          mimeType: RESOURCE_MIME_TYPE,
-          text: getHostCapabilitiesHtml,
-        },
+        widgetResourceContent(
+          GET_HOST_CAPABILITIES_URI,
+          widgetHtml("get-host-capabilities"),
+          "Displays host capabilities reported by the MCP Apps bridge.",
+          publicBaseUrl
+        ),
       ],
     })
   );
@@ -1278,7 +1409,7 @@ function createServer(): McpServer {
       title: "Get Host Context",
       description:
         "Demonstrates how a widget queries the host's environment via app.getHostContext() and " +
-        "listens for live updates via app.onhostcontextchanged. Shows theme, displayMode, locale, " +
+        "listens for live updates via openai:set_globals or app.onhostcontextchanged. Shows theme, displayMode, locale, " +
         "timeZone, platform, containerDimensions, and more. Use when the user asks how to get host " +
         "context, detect theme or locale, listen for context changes, use getHostContext, or react " +
         "to environment changes.",
@@ -1288,7 +1419,10 @@ function createServer(): McpServer {
         destructiveHint: false,
         openWorldHint: false,
       },
-      _meta: { ui: { resourceUri: GET_HOST_CONTEXT_URI } },
+      _meta: {
+        ui: { resourceUri: GET_HOST_CONTEXT_URI },
+        "openai/outputTemplate": GET_HOST_CONTEXT_URI,
+      },
     },
     async () => {
       return {
@@ -1297,8 +1431,8 @@ function createServer(): McpServer {
             type: "text" as const,
             text: [
               'The "get_host_context" tool was called.',
-              "A live widget is now displaying the host's context returned by app.getHostContext(), with live updates via onhostcontextchanged.",
-              "Explain how getHostContext provides environment info and how onhostcontextchanged enables reactive updates, tailored to the user's question.",
+              "A live widget is now displaying host context, with live updates via openai:set_globals and the MCP Apps bridge.",
+              "Explain how ChatGPT globals and getHostContext provide environment info, tailored to the user's question.",
               "Encourage follow-up questions about MCP Apps.",
             ].join(" "),
           },
@@ -1321,31 +1455,26 @@ function createServer(): McpServer {
             },
             {
               id: 2,
-              title: "Call app.getHostContext()",
+              title: "Read ChatGPT host globals",
               summary:
-                "Returns the current host environment — theme, locale, display mode, dimensions, etc.",
+                "Use window.openai globals directly or subscribe through a small useOpenAiGlobal helper",
               code: [
-                `const { app } = useApp({`,
-                `  onAppCreated: (app) => {`,
-                `    app.ontoolresult = () => { /* ... */ };`,
-                `    app.onhostcontextchanged = (ctx) => {`,
-                `      console.log("Theme:", ctx.theme);`,
-                `    };`,
-                `  },`,
+                `const theme = window.openai.theme;`,
+                `const mode = window.openai.displayMode;`,
+                `const locale = window.openai.locale;`,
+                ``,
+                `window.addEventListener("openai:set_globals", (event) => {`,
+                `  console.log(event.detail.globals.theme);`,
                 `});`,
                 ``,
-                `const ctx = app.getHostContext();`,
-                `// ctx.theme — "light" | "dark"`,
-                `// ctx.displayMode — "inline" | "fullscreen" | "pip"`,
-                `// ctx.locale — e.g. "en-US"`,
-                `// ctx.containerDimensions — { width, height }`,
+                `const displayMode = useOpenAiGlobal("displayMode");`,
               ].join("\n"),
             },
             {
               id: 3,
-              title: "Context vs Capabilities",
+              title: "Bridge context vs capabilities",
               summary:
-                "Context is dynamic (changes over time); capabilities are static (set once at connection)",
+                "For broader MCP Apps hosts, app.getHostContext() is dynamic while app.getHostCapabilities() is static",
               code: [
                 `// Dynamic — changes during session:`,
                 `const ctx = app.getHostContext();`,
@@ -1370,11 +1499,12 @@ function createServer(): McpServer {
     },
     async () => ({
       contents: [
-        {
-          uri: GET_HOST_CONTEXT_URI,
-          mimeType: RESOURCE_MIME_TYPE,
-          text: getHostContextHtml,
-        },
+        widgetResourceContent(
+          GET_HOST_CONTEXT_URI,
+          widgetHtml("get-host-context"),
+          "Displays host context and live context change notifications.",
+          publicBaseUrl
+        ),
       ],
     })
   );
@@ -1395,7 +1525,10 @@ function createServer(): McpServer {
         destructiveHint: false,
         openWorldHint: false,
       },
-      _meta: { ui: { resourceUri: GET_HOST_VERSION_URI } },
+      _meta: {
+        ui: { resourceUri: GET_HOST_VERSION_URI },
+        "openai/outputTemplate": GET_HOST_VERSION_URI,
+      },
     },
     async () => {
       return {
@@ -1482,11 +1615,12 @@ function createServer(): McpServer {
     },
     async () => ({
       contents: [
-        {
-          uri: GET_HOST_VERSION_URI,
-          mimeType: RESOURCE_MIME_TYPE,
-          text: getHostVersionHtml,
-        },
+        widgetResourceContent(
+          GET_HOST_VERSION_URI,
+          widgetHtml("get-host-version"),
+          "Displays host implementation name and version.",
+          publicBaseUrl
+        ),
       ],
     })
   );
@@ -1494,13 +1628,20 @@ function createServer(): McpServer {
   return server;
 }
 
-const port = parseInt(process.env.PORT ?? "8000", 10);
 const app = express();
 app.use(cors());
 app.use(express.json());
+app.use(
+  "/assets",
+  express.static(ASSETS_DIR, {
+    immutable: true,
+    maxAge: "1y",
+  })
+);
 
 app.all("/mcp", async (req, res) => {
-  const server = createServer();
+  const publicBaseUrl = publicBaseUrlForRequest(req);
+  const server = createServer(publicBaseUrl);
   const transport = new StreamableHTTPServerTransport({
     sessionIdGenerator: undefined,
   });
@@ -1525,8 +1666,23 @@ app.all("/mcp", async (req, res) => {
   }
 });
 
-app.listen(port, () => {
-  console.log(
-    `MCP App Basics server listening on http://localhost:${port}/mcp`
-  );
+const httpServer = app.listen(port, host, () => {
+  const localBaseUrl = configuredPublicBaseUrl
+    ? normalizedOrigin(configuredPublicBaseUrl)
+    : `http://localhost:${port}`;
+
+  console.log(`MCP App Basics server listening on ${localBaseUrl}/mcp`);
+  console.log(`Serving widget assets from ${localBaseUrl}/assets`);
+});
+
+httpServer.on("error", (error: NodeJS.ErrnoException) => {
+  if (error.code === "EADDRINUSE") {
+    console.error(
+      `Port ${port} is already in use on ${host}. Stop the existing server or start with PORT=<another-port> pnpm start.`
+    );
+    process.exit(1);
+  }
+
+  console.error("MCP App Basics server failed to start:", error);
+  process.exit(1);
 });

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "host/main.ts",
   "scripts": {
-    "build": "tsx ./build-all.mts",
+    "build": "node --import tsx ./build-all.mts",
     "serve": "serve -s ./assets -p 4444 --cors",
     "dev": "vite --config vite.config.mts",
     "tsc": "tsc -b",

--- a/src/call-server-tool/App.tsx
+++ b/src/call-server-tool/App.tsx
@@ -1,19 +1,13 @@
 import { useApp } from "@modelcontextprotocol/ext-apps/react";
 import type { App as McpApp } from "@modelcontextprotocol/ext-apps";
 import { useState } from "react";
-import { HighlightedCode } from "../highlight-code";
-
-interface Step {
-  id: number;
-  title: string;
-  summary: string;
-  code?: string;
-}
-
-interface DemoData {
-  toolName: string;
-  steps: Step[];
-}
+import { Badge } from "@openai/apps-sdk-ui/components/Badge";
+import { Button } from "@openai/apps-sdk-ui/components/Button";
+import { SegmentedControl } from "@openai/apps-sdk-ui/components/SegmentedControl";
+import { ArrowRotateCw } from "@openai/apps-sdk-ui/components/Icon";
+import { BasicsShell, CodeWalkthrough, KeyValueGrid, StatusAlert } from "../mcp-app-basics/components";
+import { callTool, type ToolResultLike } from "../mcp-app-basics/openai-helpers";
+import type { DemoData } from "../mcp-app-basics/types";
 
 type DiceSides = 6 | 12 | 20;
 type Status = "idle" | "rolling" | "error";
@@ -21,6 +15,25 @@ type Status = "idle" | "rolling" | "error";
 interface RollResult {
   sides: number;
   rolled: number;
+}
+
+function parseRollResult(toolResult: ToolResultLike): RollResult | null {
+  const structured = toolResult.structuredContent;
+  if (
+    structured &&
+    typeof structured === "object" &&
+    "sides" in structured &&
+    "rolled" in structured
+  ) {
+    return structured as RollResult;
+  }
+
+  const text = toolResult.content
+    ?.filter((c): c is { type: string; text: string } => c.type === "text")
+    .map((c) => c.text)
+    .join(" ");
+
+  return text ? (JSON.parse(text) as RollResult) : null;
 }
 
 export default function App() {
@@ -43,26 +56,16 @@ export default function App() {
   });
 
   if (error) {
-    return (
-      <div className="flex items-center justify-center min-h-32 p-4">
-        <p className="text-red-600 text-sm">Connection failed: {error.message}</p>
-      </div>
-    );
+    return <BasicsShell title="Call Server Tool" error={error} isConnected={false} />;
   }
 
   if (!app) {
-    return (
-      <div className="flex items-center justify-center min-h-32 p-4">
-        <p className="text-gray-500 text-sm">Connecting...</p>
-      </div>
-    );
+    return <BasicsShell title="Call Server Tool" isConnected={false} />;
   }
 
   if (!ready) {
     return (
-      <div className="flex items-center justify-center min-h-32 p-4">
-        <p className="text-gray-500 text-sm">Waiting for tool result...</p>
-      </div>
+      <BasicsShell title="Call Server Tool" isConnected={true} isReady={false} />
     );
   }
 
@@ -71,9 +74,8 @@ export default function App() {
     setErrorMsg(null);
 
     try {
-      const toolResult = await app.callServerTool({
-        name: "call_server_tool__roll_dice",
-        arguments: { sides },
+      const toolResult = await callTool(app, "call_server_tool__roll_dice", {
+        sides,
       });
 
       if (toolResult.isError) {
@@ -84,12 +86,7 @@ export default function App() {
           .join(" ");
         setErrorMsg(text || "Tool returned an error.");
       } else {
-        const text = toolResult.content
-          ?.filter((c): c is { type: "text"; text: string } => c.type === "text")
-          .map((c) => c.text)
-          .join(" ");
-        const parsed = text ? JSON.parse(text) : null;
-        setResult(parsed);
+        setResult(parseRollResult(toolResult));
         setStatus("idle");
       }
     } catch (err) {
@@ -99,91 +96,56 @@ export default function App() {
   };
 
   return (
-    <div className="flex items-center justify-center p-4">
-      <div className="bg-white rounded-2xl shadow-lg border border-gray-200 p-6 max-w-xl w-full">
-        <h1 className="text-2xl font-bold text-gray-900 mb-2">Call Server Tool</h1>
-        <p className="text-gray-600 mb-4">
-          Roll a dice by calling an app-only server tool directly from the widget — no model involved.
-        </p>
-
-        <div className="flex items-center gap-3 mb-3">
-          <label className="text-sm text-gray-700 font-medium">Sides:</label>
-          <div className="flex gap-2">
-            {([6, 12, 20] as DiceSides[]).map((n) => (
-              <button
-                key={n}
-                onClick={() => setSides(n)}
-                className={`px-3 py-1.5 text-sm rounded-lg border font-medium ${
-                  sides === n
-                    ? "bg-blue-600 text-white border-blue-600"
-                    : "bg-white text-gray-700 border-gray-300 hover:border-gray-400"
-                }`}
-              >
-                d{n}
-              </button>
-            ))}
-          </div>
-          <button
-            onClick={handleRoll}
-            disabled={status === "rolling"}
-            className="px-4 py-1.5 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            {status === "rolling" ? "Rolling..." : "Roll"}
-          </button>
-        </div>
-
-        {result && status === "idle" && (
-          <div className="mb-3 px-4 py-3 bg-blue-50 border border-blue-200 rounded-lg">
-            <span className="text-3xl font-bold text-blue-700">{result.rolled}</span>
-            <span className="text-sm text-blue-500 ml-2">on a d{result.sides}</span>
-          </div>
-        )}
-
-        {status === "error" && (
-          <p className="text-red-600 text-xs mb-3">{errorMsg || "Failed to call tool."}</p>
-        )}
-
-        {data && (
-          <details className="mt-4 border-t border-gray-100 pt-3">
-            <summary className="text-sm text-gray-500 cursor-pointer hover:text-gray-700">
-              See the code and explanation...
-            </summary>
-            <ol className="mt-3 space-y-4 text-sm text-gray-500">
-              {data.steps.map((step) => (
-                <li key={step.id}>
-                  <span className="font-medium text-gray-700">
-                    {step.id}. {step.title}
-                  </span>
-                  <span className="text-gray-400"> — {step.summary}</span>
-                  {step.code && (
-                    <pre className="mt-1.5 px-3 py-2.5 bg-gray-900 text-gray-300 text-xs leading-relaxed rounded-lg overflow-x-auto whitespace-pre">
-                      <code><HighlightedCode code={step.code} /></code>
-                    </pre>
-                  )}
-                </li>
-              ))}
-            </ol>
-            <div className="mt-3 text-xs text-gray-400 space-y-1">
-              <a
-                href="https://modelcontextprotocol.io/docs/extensions/apps"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="block hover:text-blue-500 underline"
-              >
-                MCP Apps docs
-              </a>
-              <a
-                href="https://modelcontextprotocol.github.io/ext-apps/api/"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="block hover:text-blue-500 underline"
-              >
-                API reference
-              </a>
-            </div>
-          </details>
-        )}
+    <BasicsShell
+      title="Call Server Tool"
+      description="Roll a die by calling an app-only MCP tool directly from the widget. The model does not participate in the reroll."
+      isConnected={true}
+      badge={<Badge color="discovery">app-only tool</Badge>}
+    >
+      <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center">
+        <SegmentedControl
+          value={String(sides)}
+          onChange={(next) => setSides(Number(next) as DiceSides)}
+          aria-label="Dice sides"
+          size="md"
+        >
+          <SegmentedControl.Option value="6">d6</SegmentedControl.Option>
+          <SegmentedControl.Option value="12">d12</SegmentedControl.Option>
+          <SegmentedControl.Option value="20">d20</SegmentedControl.Option>
+        </SegmentedControl>
+        <Button
+          color="primary"
+          onClick={() => void handleRoll()}
+          disabled={status === "rolling"}
+          loading={status === "rolling"}
+          className="w-fit"
+        >
+          <ArrowRotateCw />
+          {status === "rolling" ? "Rolling" : "Roll"}
+        </Button>
       </div>
-    </div>
+
+      {result && status === "idle" ? (
+        <div className="mb-4 rounded-lg border border-subtle bg-surface-secondary p-3">
+          <KeyValueGrid
+            className="mb-0"
+            rows={[
+              { label: "rolled", value: <span className="text-2xl font-semibold">{result.rolled}</span> },
+              { label: "sides", value: `d${result.sides}` },
+            ]}
+          />
+        </div>
+      ) : null}
+
+      {status === "error" ? (
+        <StatusAlert
+          tone="danger"
+          title="Tool call failed"
+          description={errorMsg || "The app-only tool returned an error."}
+        />
+      ) : null}
+
+      <CodeWalkthrough steps={data?.steps} />
+    </BasicsShell>
   );
 }

--- a/src/get-host-capabilities/App.tsx
+++ b/src/get-host-capabilities/App.tsx
@@ -1,19 +1,10 @@
 import { useApp } from "@modelcontextprotocol/ext-apps/react";
 import type { App as McpApp } from "@modelcontextprotocol/ext-apps";
 import { useState } from "react";
-import { HighlightedCode } from "../highlight-code";
-
-interface Step {
-  id: number;
-  title: string;
-  summary: string;
-  code?: string;
-}
-
-interface DemoData {
-  toolName: string;
-  steps: Step[];
-}
+import { Badge } from "@openai/apps-sdk-ui/components/Badge";
+import { CodeBlock } from "@openai/apps-sdk-ui/components/CodeBlock";
+import { BasicsShell, CodeWalkthrough, StatusAlert } from "../mcp-app-basics/components";
+import type { DemoData } from "../mcp-app-basics/types";
 
 const CAPABILITY_KEYS = [
   "openLinks",
@@ -46,112 +37,68 @@ export default function App() {
   });
 
   if (error) {
-    return (
-      <div className="flex items-center justify-center min-h-32 p-4">
-        <p className="text-red-600 text-sm">Connection failed: {error.message}</p>
-      </div>
-    );
+    return <BasicsShell title="Host Capabilities" error={error} isConnected={false} />;
   }
 
   if (!app) {
-    return (
-      <div className="flex items-center justify-center min-h-32 p-4">
-        <p className="text-gray-500 text-sm">Connecting...</p>
-      </div>
-    );
+    return <BasicsShell title="Host Capabilities" isConnected={false} />;
   }
 
   if (!data) {
     return (
-      <div className="flex items-center justify-center min-h-32 p-4">
-        <p className="text-gray-500 text-sm">Waiting for tool result...</p>
-      </div>
+      <BasicsShell title="Host Capabilities" isConnected={true} isReady={false} />
     );
   }
 
   return (
-    <div className="flex items-center justify-center p-4">
-      <div className="bg-white rounded-2xl shadow-lg border border-gray-200 p-6 max-w-xl w-full">
-        <h1 className="text-2xl font-bold text-gray-900 mb-2">Host Capabilities</h1>
-        <p className="text-gray-600 mb-4">
-          What the host supports, returned by <code className="text-sm bg-gray-100 px-1 py-0.5 rounded">app.getHostCapabilities()</code>.
-        </p>
-
-        <table className="w-full text-sm border-collapse mb-4">
-          <thead>
-            <tr className="border-b border-gray-200">
-              <th className="text-left py-2 text-gray-500 font-medium">Capability</th>
-              <th className="text-left py-2 text-gray-500 font-medium">Status</th>
-              <th className="text-left py-2 text-gray-500 font-medium">Detail</th>
-            </tr>
-          </thead>
-          <tbody>
-            {CAPABILITY_KEYS.map((key) => {
-              const value = capabilities?.[key];
-              const supported = value !== undefined && value !== null && value !== false;
-              return (
-                <tr key={key} className="border-b border-gray-100">
-                  <td className="py-2 font-mono text-xs text-gray-700">{key}</td>
-                  <td className="py-2">
-                    <span className={`inline-block px-2 py-0.5 rounded text-xs font-medium ${supported ? "bg-green-100 text-green-700" : "bg-gray-100 text-gray-400"}`}>
-                      {supported ? "supported" : "not reported"}
-                    </span>
-                  </td>
-                  <td className="py-2 font-mono text-xs text-gray-500">
-                    {supported ? (typeof value === "object" ? JSON.stringify(value) : String(value)) : "—"}
-                  </td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
-
-        <div className="p-3 bg-gray-50 rounded-lg text-xs text-gray-500 space-y-1">
-          <p><strong className="text-gray-700">How it works:</strong> Call <code>app.getHostCapabilities()</code> after connection to discover what the host supports.</p>
-          <p>Capabilities are set once at connection time and do not change.</p>
-        </div>
-
-        {data && (
-          <details className="mt-4 border-t border-gray-100 pt-3">
-            <summary className="text-sm text-gray-500 cursor-pointer hover:text-gray-700">
-              See the code and explanation...
-            </summary>
-            <ol className="mt-3 space-y-4 text-sm text-gray-500">
-              {data.steps.map((step) => (
-                <li key={step.id}>
-                  <span className="font-medium text-gray-700">
-                    {step.id}. {step.title}
-                  </span>
-                  <span className="text-gray-400"> — {step.summary}</span>
-                  {step.code && (
-                    <pre className="mt-1.5 px-3 py-2.5 bg-gray-900 text-gray-300 text-xs leading-relaxed rounded-lg overflow-x-auto whitespace-pre">
-                      <code><HighlightedCode code={step.code} /></code>
-                    </pre>
-                  )}
-                </li>
-              ))}
-            </ol>
-            <div className="mt-3 text-xs text-gray-400 space-y-1">
-              <a
-                href="https://modelcontextprotocol.io/docs/extensions/apps"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="block hover:text-blue-500 underline"
-              >
-                MCP Apps docs
-              </a>
-              <a
-                href="https://modelcontextprotocol.github.io/ext-apps/api/"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="block hover:text-blue-500 underline"
-              >
-                API reference
-              </a>
+    <BasicsShell
+      title="Host Capabilities"
+      description="Capabilities advertised during the MCP Apps bridge initialization. This is an ext-apps bridge example."
+      isConnected={true}
+      badge={<Badge color="discovery">MCP bridge</Badge>}
+    >
+      <div className="mb-4 divide-y divide-subtle rounded-lg border border-subtle">
+        {CAPABILITY_KEYS.map((key) => {
+          const value = capabilities?.[key];
+          const supported =
+            value !== undefined && value !== null && value !== false;
+          return (
+            <div
+              key={key}
+              className="grid gap-2 p-3 sm:grid-cols-[minmax(8rem,1fr)_auto_minmax(10rem,1.2fr)] sm:items-start"
+            >
+              <span className="font-mono text-xs text-primary">{key}</span>
+              <Badge color={supported ? "success" : "secondary"} variant="soft">
+                {supported ? "supported" : "not reported"}
+              </Badge>
+              <span className="min-w-0 break-words font-mono text-xs text-secondary">
+                {supported
+                  ? typeof value === "object"
+                    ? JSON.stringify(value)
+                    : String(value)
+                  : "not reported"}
+              </span>
             </div>
-          </details>
-        )}
+          );
+        })}
       </div>
-    </div>
+
+      <StatusAlert
+        tone="info"
+        title="How it works"
+        description="Call app.getHostCapabilities() after connection. These capabilities are set by the host during initialization."
+      />
+
+      <div className="mt-4">
+        <p className="mb-2 text-xs font-medium uppercase text-secondary">
+          Raw capabilities
+        </p>
+        <CodeBlock language="json">
+          {JSON.stringify(capabilities ?? {}, null, 2)}
+        </CodeBlock>
+      </div>
+
+      <CodeWalkthrough steps={data.steps} />
+    </BasicsShell>
   );
 }

--- a/src/get-host-context/App.tsx
+++ b/src/get-host-context/App.tsx
@@ -1,19 +1,10 @@
 import { useApp } from "@modelcontextprotocol/ext-apps/react";
 import type { App as McpApp } from "@modelcontextprotocol/ext-apps";
 import { useState, useCallback } from "react";
-import { HighlightedCode } from "../highlight-code";
-
-interface Step {
-  id: number;
-  title: string;
-  summary: string;
-  code?: string;
-}
-
-interface DemoData {
-  toolName: string;
-  steps: Step[];
-}
+import { Badge } from "@openai/apps-sdk-ui/components/Badge";
+import { CodeBlock } from "@openai/apps-sdk-ui/components/CodeBlock";
+import { BasicsShell, CodeWalkthrough, KeyValueGrid, StatusAlert } from "../mcp-app-basics/components";
+import type { DemoData } from "../mcp-app-basics/types";
 
 export default function App() {
   const [data, setData] = useState<DemoData | null>(null);
@@ -47,141 +38,83 @@ export default function App() {
   });
 
   if (error) {
-    return (
-      <div className="flex items-center justify-center min-h-32 p-4">
-        <p className="text-red-600 text-sm">Connection failed: {error.message}</p>
-      </div>
-    );
+    return <BasicsShell title="Host Context" error={error} isConnected={false} />;
   }
 
   if (!app) {
-    return (
-      <div className="flex items-center justify-center min-h-32 p-4">
-        <p className="text-gray-500 text-sm">Connecting...</p>
-      </div>
-    );
+    return <BasicsShell title="Host Context" isConnected={false} />;
   }
 
   if (!data) {
     return (
-      <div className="flex items-center justify-center min-h-32 p-4">
-        <p className="text-gray-500 text-sm">Waiting for tool result...</p>
-      </div>
+      <BasicsShell title="Host Context" isConnected={true} isReady={false} />
     );
   }
 
   const SIMPLE_KEYS = ["theme", "displayMode", "locale", "timeZone", "platform"] as const;
   const ARRAY_KEYS = ["availableDisplayModes"] as const;
   const OBJECT_KEYS = ["containerDimensions", "deviceCapabilities"] as const;
+  const simpleRows = SIMPLE_KEYS.map((key) => {
+    const value = context?.[key];
+    return {
+      label: key,
+      value:
+        value !== undefined && value !== null ? String(value) : "not reported",
+    };
+  });
+  const arrayRows = ARRAY_KEYS.map((key) => {
+    const value = context?.[key];
+    return {
+      label: key,
+      value: Array.isArray(value) ? value.join(", ") : "not reported",
+    };
+  });
 
   return (
-    <div className="flex items-center justify-center p-4">
-      <div className="bg-white rounded-2xl shadow-lg border border-gray-200 p-6 max-w-xl w-full">
-        <h1 className="text-2xl font-bold text-gray-900 mb-2">Host Context</h1>
-        <p className="text-gray-600 mb-4">
-          Live environment info from <code className="text-sm bg-gray-100 px-1 py-0.5 rounded">app.getHostContext()</code>.
-        </p>
+    <BasicsShell
+      title="Host Context"
+      description="Live environment data from the MCP Apps bridge, including theme, display mode, locale, and layout hints."
+      isConnected={true}
+      badge={<Badge color="discovery">MCP bridge</Badge>}
+    >
+      {lastUpdated ? (
+        <StatusAlert
+          tone="success"
+          title={`Last updated: ${lastUpdated}`}
+          description={
+            updateCount > 0
+              ? `${updateCount} live update${updateCount !== 1 ? "s" : ""}`
+              : "Initial host context captured."
+          }
+        />
+      ) : null}
 
-        {lastUpdated && (
-          <div className="flex items-center gap-2 mb-4 text-xs text-gray-400">
-            <span className="inline-block w-2 h-2 rounded-full bg-green-400 animate-pulse" />
-            Last updated: {lastUpdated}
-            {updateCount > 0 && <span>({updateCount} live update{updateCount !== 1 ? "s" : ""})</span>}
-          </div>
-        )}
+      <KeyValueGrid rows={[...simpleRows, ...arrayRows]} />
 
-        <div className="space-y-3 mb-4">
-          {SIMPLE_KEYS.map((key) => {
-            const value = context?.[key];
-            return (
-              <div key={key} className="flex items-baseline gap-2">
-                <span className="font-mono text-xs text-gray-500 w-40 shrink-0">{key}</span>
-                <span className="font-mono text-sm text-gray-800">
-                  {value !== undefined && value !== null ? String(value) : <span className="text-gray-300">—</span>}
-                </span>
-              </div>
-            );
-          })}
-
-          {ARRAY_KEYS.map((key) => {
-            const value = context?.[key];
-            return (
-              <div key={key} className="flex items-baseline gap-2">
-                <span className="font-mono text-xs text-gray-500 w-40 shrink-0">{key}</span>
-                <span className="font-mono text-sm text-gray-800">
-                  {Array.isArray(value) ? value.join(", ") : <span className="text-gray-300">—</span>}
-                </span>
-              </div>
-            );
-          })}
-
-          {OBJECT_KEYS.map((key) => {
-            const value = context?.[key];
-            if (!value || typeof value !== "object") {
-              return (
-                <div key={key} className="flex items-baseline gap-2">
-                  <span className="font-mono text-xs text-gray-500 w-40 shrink-0">{key}</span>
-                  <span className="text-gray-300 text-sm">—</span>
-                </div>
-              );
-            }
-            return (
-              <div key={key}>
-                <span className="font-mono text-xs text-gray-500">{key}</span>
-                <pre className="mt-1 px-3 py-2 bg-gray-50 rounded-lg text-xs text-gray-700 overflow-x-auto">
-                  {JSON.stringify(value, null, 2)}
-                </pre>
-              </div>
-            );
-          })}
-        </div>
-
-        <div className="p-3 bg-gray-50 rounded-lg text-xs text-gray-500 space-y-1">
-          <p><strong className="text-gray-700">How it works:</strong> Call <code>app.getHostContext()</code> after connection. Register <code>app.onhostcontextchanged</code> for live updates.</p>
-          <p>Context changes when the user switches theme, resizes the widget, or changes display mode.</p>
-        </div>
-
-        {data && (
-          <details className="mt-4 border-t border-gray-100 pt-3">
-            <summary className="text-sm text-gray-500 cursor-pointer hover:text-gray-700">
-              See the code and explanation...
-            </summary>
-            <ol className="mt-3 space-y-4 text-sm text-gray-500">
-              {data.steps.map((step) => (
-                <li key={step.id}>
-                  <span className="font-medium text-gray-700">
-                    {step.id}. {step.title}
-                  </span>
-                  <span className="text-gray-400"> — {step.summary}</span>
-                  {step.code && (
-                    <pre className="mt-1.5 px-3 py-2.5 bg-gray-900 text-gray-300 text-xs leading-relaxed rounded-lg overflow-x-auto whitespace-pre">
-                      <code><HighlightedCode code={step.code} /></code>
-                    </pre>
-                  )}
-                </li>
-              ))}
-            </ol>
-            <div className="mt-3 text-xs text-gray-400 space-y-1">
-              <a
-                href="https://modelcontextprotocol.io/docs/extensions/apps"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="block hover:text-blue-500 underline"
-              >
-                MCP Apps docs
-              </a>
-              <a
-                href="https://modelcontextprotocol.github.io/ext-apps/api/"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="block hover:text-blue-500 underline"
-              >
-                API reference
-              </a>
+      <div className="space-y-3">
+        {OBJECT_KEYS.map((key) => {
+          const value = context?.[key];
+          return (
+            <div key={key} className="space-y-1">
+              <p className="font-mono text-xs text-secondary">{key}</p>
+              <CodeBlock language="json">
+                {value && typeof value === "object"
+                  ? JSON.stringify(value, null, 2)
+                  : "not reported"}
+              </CodeBlock>
             </div>
-          </details>
-        )}
+          );
+        })}
       </div>
-    </div>
+
+      <StatusAlert
+        tone="info"
+        title="How it works"
+        description="Call app.getHostContext() after connection, then subscribe to app.onhostcontextchanged for updates."
+        className="mt-4"
+      />
+
+      <CodeWalkthrough steps={data.steps} />
+    </BasicsShell>
   );
 }

--- a/src/get-host-version/App.tsx
+++ b/src/get-host-version/App.tsx
@@ -1,19 +1,9 @@
 import { useApp } from "@modelcontextprotocol/ext-apps/react";
 import type { App as McpApp } from "@modelcontextprotocol/ext-apps";
 import { useState } from "react";
-import { HighlightedCode } from "../highlight-code";
-
-interface Step {
-  id: number;
-  title: string;
-  summary: string;
-  code?: string;
-}
-
-interface DemoData {
-  toolName: string;
-  steps: Step[];
-}
+import { Badge } from "@openai/apps-sdk-ui/components/Badge";
+import { BasicsShell, CodeWalkthrough, KeyValueGrid, StatusAlert } from "../mcp-app-basics/components";
+import type { DemoData } from "../mcp-app-basics/types";
 
 interface HostVersion {
   name?: string;
@@ -41,98 +31,40 @@ export default function App() {
   });
 
   if (error) {
-    return (
-      <div className="flex items-center justify-center min-h-32 p-4">
-        <p className="text-red-600 text-sm">Connection failed: {error.message}</p>
-      </div>
-    );
+    return <BasicsShell title="Host Version" error={error} isConnected={false} />;
   }
 
   if (!app) {
-    return (
-      <div className="flex items-center justify-center min-h-32 p-4">
-        <p className="text-gray-500 text-sm">Connecting...</p>
-      </div>
-    );
+    return <BasicsShell title="Host Version" isConnected={false} />;
   }
 
   if (!data) {
     return (
-      <div className="flex items-center justify-center min-h-32 p-4">
-        <p className="text-gray-500 text-sm">Waiting for tool result...</p>
-      </div>
+      <BasicsShell title="Host Version" isConnected={true} isReady={false} />
     );
   }
 
   return (
-    <div className="flex items-center justify-center p-4">
-      <div className="bg-white rounded-2xl shadow-lg border border-gray-200 p-6 max-w-xl w-full">
-        <h1 className="text-2xl font-bold text-gray-900 mb-2">Host Version</h1>
-        <p className="text-gray-600 mb-4">
-          Host identity from <code className="text-sm bg-gray-100 px-1 py-0.5 rounded">app.getHostVersion()</code>.
-        </p>
+    <BasicsShell
+      title="Host Version"
+      description="Host implementation identity from the MCP Apps bridge. This is useful for diagnostics and feature logging."
+      isConnected={true}
+      badge={<Badge color="discovery">MCP bridge</Badge>}
+    >
+      <KeyValueGrid
+        rows={[
+          { label: "name", value: hostVersion?.name ?? "not reported" },
+          { label: "version", value: hostVersion?.version ?? "not reported" },
+        ]}
+      />
 
-        <div className="space-y-3 mb-4">
-          <div className="flex items-baseline gap-2">
-            <span className="font-mono text-xs text-gray-500 w-24 shrink-0">name</span>
-            <span className="font-mono text-lg text-gray-800">
-              {hostVersion?.name ?? <span className="text-gray-300">—</span>}
-            </span>
-          </div>
-          <div className="flex items-baseline gap-2">
-            <span className="font-mono text-xs text-gray-500 w-24 shrink-0">version</span>
-            <span className="font-mono text-lg text-gray-800">
-              {hostVersion?.version ?? <span className="text-gray-300">—</span>}
-            </span>
-          </div>
-        </div>
+      <StatusAlert
+        tone="info"
+        title="How it works"
+        description="Call app.getHostVersion() after connection to identify the host application and version."
+      />
 
-        <div className="p-3 bg-gray-50 rounded-lg text-xs text-gray-500 space-y-1">
-          <p><strong className="text-gray-700">How it works:</strong> Call <code>app.getHostVersion()</code> after connection to identify the host application and version.</p>
-          <p>Useful for feature detection or logging which host is running your app.</p>
-        </div>
-
-        {data && (
-          <details className="mt-4 border-t border-gray-100 pt-3">
-            <summary className="text-sm text-gray-500 cursor-pointer hover:text-gray-700">
-              See the code and explanation...
-            </summary>
-            <ol className="mt-3 space-y-4 text-sm text-gray-500">
-              {data.steps.map((step) => (
-                <li key={step.id}>
-                  <span className="font-medium text-gray-700">
-                    {step.id}. {step.title}
-                  </span>
-                  <span className="text-gray-400"> — {step.summary}</span>
-                  {step.code && (
-                    <pre className="mt-1.5 px-3 py-2.5 bg-gray-900 text-gray-300 text-xs leading-relaxed rounded-lg overflow-x-auto whitespace-pre">
-                      <code><HighlightedCode code={step.code} /></code>
-                    </pre>
-                  )}
-                </li>
-              ))}
-            </ol>
-            <div className="mt-3 text-xs text-gray-400 space-y-1">
-              <a
-                href="https://modelcontextprotocol.io/docs/extensions/apps"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="block hover:text-blue-500 underline"
-              >
-                MCP Apps docs
-              </a>
-              <a
-                href="https://modelcontextprotocol.github.io/ext-apps/api/"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="block hover:text-blue-500 underline"
-              >
-                API reference
-              </a>
-            </div>
-          </details>
-        )}
-      </div>
-    </div>
+      <CodeWalkthrough steps={data.steps} />
+    </BasicsShell>
   );
 }

--- a/src/host-theming/App.tsx
+++ b/src/host-theming/App.tsx
@@ -5,19 +5,10 @@ import {
 } from "@modelcontextprotocol/ext-apps/react";
 import type { App as McpApp } from "@modelcontextprotocol/ext-apps";
 import { useState } from "react";
-import { HighlightedCode } from "../highlight-code";
-
-interface Step {
-  id: number;
-  title: string;
-  summary: string;
-  code?: string;
-}
-
-interface DemoData {
-  toolName: string;
-  steps: Step[];
-}
+import { Badge } from "@openai/apps-sdk-ui/components/Badge";
+import { ColorTheme } from "@openai/apps-sdk-ui/components/Icon";
+import { BasicsShell, CodeWalkthrough, KeyValueGrid } from "../mcp-app-basics/components";
+import type { DemoData } from "../mcp-app-basics/types";
 
 const CSS_VARS_TO_SHOW = [
   "--color-background-primary",
@@ -45,175 +36,59 @@ export default function App() {
   const theme = useDocumentTheme();
 
   if (error) {
-    return (
-      <div style={{ padding: 16, textAlign: "center" }}>
-        <p style={{ color: "red", fontSize: 14 }}>
-          Connection failed: {error.message}
-        </p>
-      </div>
-    );
+    return <BasicsShell title="Host Theming" error={error} isConnected={false} />;
   }
 
   if (!app) {
-    return (
-      <div style={{ padding: 16, textAlign: "center" }}>
-        <p style={{ fontSize: 14, opacity: 0.6 }}>Connecting...</p>
-      </div>
-    );
+    return <BasicsShell title="Host Theming" isConnected={false} />;
   }
 
   if (!data) {
     return (
-      <div style={{ padding: 16, textAlign: "center" }}>
-        <p style={{ fontSize: 14, opacity: 0.6 }}>Waiting for tool result...</p>
-      </div>
+      <BasicsShell title="Host Theming" isConnected={true} isReady={false} />
     );
   }
 
   return (
-    <div style={{ display: "flex", justifyContent: "center", padding: 16 }}>
-      <div
-        style={{
-          background: "var(--color-background-primary)",
-          color: "var(--color-text-primary)",
-          border: "1px solid var(--color-border-light)",
-          borderRadius: "var(--border-radius-md, 1rem)",
-          padding: 24,
-          maxWidth: 560,
-          width: "100%",
-          boxShadow: "0 4px 12px rgba(0,0,0,0.08)",
-        }}
-      >
-        <h1 style={{ fontSize: 24, fontWeight: 700, margin: "0 0 8px" }}>
-          Host Theming
-        </h1>
-        <p style={{ color: "var(--color-text-secondary)", margin: "0 0 16px" }}>
-          This card is styled entirely with the host's CSS variables. It adapts automatically.
-        </p>
-
-        <div
-          style={{
-            background: "var(--color-background-secondary)",
-            border: "1px solid var(--color-border-light)",
-            borderRadius: "var(--border-radius-md, 0.5rem)",
-            padding: "12px 16px",
-            marginBottom: 16,
-          }}
-        >
-          <p style={{ fontSize: 14, fontWeight: 500, margin: "0 0 8px" }}>
-            Current theme:{" "}
-            <span style={{ fontFamily: "monospace", fontWeight: 700 }}>{theme}</span>
-          </p>
-          <table style={{ width: "100%", fontSize: 12, borderCollapse: "collapse" }}>
-            <thead>
-              <tr>
-                {["Variable", "Value", "Preview"].map((h) => (
-                  <th
-                    key={h}
-                    style={{
-                      textAlign: "left",
-                      paddingBottom: 4,
-                      fontWeight: 500,
-                      color: "var(--color-text-secondary)",
-                    }}
-                  >
-                    {h}
-                  </th>
-                ))}
-              </tr>
-            </thead>
-            <tbody>
-              {CSS_VARS_TO_SHOW.map((varName) => {
-                const value =
-                  typeof window !== "undefined"
-                    ? getComputedStyle(document.documentElement)
-                        .getPropertyValue(varName)
-                        .trim()
-                    : "";
-                const isColor = varName.startsWith("--color-");
-                return (
-                  <tr key={varName}>
-                    <td style={{ padding: "2px 0", fontFamily: "monospace" }}>{varName}</td>
-                    <td style={{ padding: "2px 0", fontFamily: "monospace" }}>{value || "(unset)"}</td>
-                    <td style={{ padding: "2px 0" }}>
-                      {isColor && value && (
-                        <span
-                          style={{
-                            display: "inline-block",
-                            width: 16,
-                            height: 16,
-                            borderRadius: 3,
-                            background: `var(${varName})`,
-                            border: "1px solid var(--color-border-light)",
-                            verticalAlign: "middle",
-                          }}
-                        />
-                      )}
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
-
-        {data && (
-          <details style={{ borderTop: "1px solid var(--color-border-light)", paddingTop: 12 }}>
-            <summary
-              style={{ fontSize: 14, cursor: "pointer", color: "var(--color-text-secondary)" }}
-            >
-              See the code and explanation...
-            </summary>
-            <ol style={{ margin: "12px 0 0", padding: 0, listStyle: "none", color: "var(--color-text-secondary)" }}>
-              {data.steps.map((step) => (
-                <li key={step.id} style={{ marginBottom: 16, fontSize: 14 }}>
-                  <span style={{ fontWeight: 500, color: "var(--color-text-primary)" }}>
-                    {step.id}. {step.title}
-                  </span>
-                  <span style={{ color: "var(--color-text-secondary)" }}>
-                    {" "}&mdash; {step.summary}
-                  </span>
-                  {step.code && (
-                    <pre
-                      style={{
-                        marginTop: 6,
-                        padding: "10px 12px",
-                        fontSize: 12,
-                        lineHeight: 1.5,
-                        borderRadius: 8,
-                        overflowX: "auto",
-                        whiteSpace: "pre",
-                        background: theme === "dark" ? "#1e1e1e" : "#1a1a2e",
-                        color: "#d1d5db",
-                      }}
-                    >
-                      <code><HighlightedCode code={step.code} /></code>
-                    </pre>
-                  )}
-                </li>
-              ))}
-            </ol>
-            <div style={{ marginTop: 12, fontSize: 12, color: "var(--color-text-secondary)" }}>
-              <a
-                href="https://modelcontextprotocol.io/docs/extensions/apps"
-                target="_blank"
-                rel="noopener noreferrer"
-                style={{ display: "block", textDecoration: "underline", marginBottom: 4 }}
-              >
-                MCP Apps docs
-              </a>
-              <a
-                href="https://modelcontextprotocol.github.io/ext-apps/api/"
-                target="_blank"
-                rel="noopener noreferrer"
-                style={{ display: "block", textDecoration: "underline" }}
-              >
-                API reference
-              </a>
-            </div>
-          </details>
-        )}
+    <BasicsShell
+      title="Host Theming"
+      description="This widget uses host CSS variables and Apps SDK UI tokens, so it follows the current ChatGPT theme."
+      isConnected={true}
+      badge={
+        <Badge color={theme === "dark" ? "discovery" : "info"}>
+          <ColorTheme className="size-3" />
+          {theme}
+        </Badge>
+      }
+    >
+      <div className="mb-4 rounded-lg border border-subtle bg-surface-secondary p-3">
+        <KeyValueGrid
+          className="mb-0"
+          rows={CSS_VARS_TO_SHOW.map((varName) => {
+            const value =
+              typeof window !== "undefined"
+                ? getComputedStyle(document.documentElement)
+                    .getPropertyValue(varName)
+                    .trim()
+                : "";
+            const isColor = varName.startsWith("--color-");
+            return {
+              label: varName,
+              value: value || "(unset)",
+              badge:
+                isColor && value ? (
+                  <span
+                    aria-hidden="true"
+                    className="inline-block size-4 rounded border border-subtle"
+                    style={{ background: `var(${varName})` }}
+                  />
+                ) : null,
+            };
+          })}
+        />
       </div>
-    </div>
+
+      <CodeWalkthrough steps={data.steps} />
+    </BasicsShell>
   );
 }

--- a/src/mcp-app-basics/components.tsx
+++ b/src/mcp-app-basics/components.tsx
@@ -1,0 +1,233 @@
+import { Alert } from "@openai/apps-sdk-ui/components/Alert";
+import { Badge } from "@openai/apps-sdk-ui/components/Badge";
+import { CodeBlock } from "@openai/apps-sdk-ui/components/CodeBlock";
+import { LoadingIndicator } from "@openai/apps-sdk-ui/components/Indicator";
+import { TextLink } from "@openai/apps-sdk-ui/components/TextLink";
+import type { ReactNode } from "react";
+import type { Step } from "./types";
+
+type StatusTone = "info" | "success" | "warning" | "danger" | "caution";
+
+export function BasicsShell({
+  title,
+  description,
+  children = null,
+  error,
+  isConnected,
+  isReady = true,
+  waitingMessage = "Waiting for tool result...",
+  expanded = false,
+  badge,
+}: {
+  title: ReactNode;
+  description?: ReactNode;
+  children?: ReactNode;
+  error?: Error | null;
+  isConnected: boolean;
+  isReady?: boolean;
+  waitingMessage?: string;
+  expanded?: boolean;
+  badge?: ReactNode;
+}) {
+  if (error) {
+    return (
+      <BasicsEmptyState
+        tone="danger"
+        title="Connection failed"
+        description={error.message}
+      />
+    );
+  }
+
+  if (!isConnected) {
+    return (
+      <BasicsEmptyState
+        tone="info"
+        title="Connecting"
+        description="Opening the MCP Apps bridge."
+        loading
+      />
+    );
+  }
+
+  if (!isReady) {
+    return (
+      <BasicsEmptyState tone="info" title={waitingMessage} loading />
+    );
+  }
+
+  return (
+    <main
+      className={
+        expanded
+          ? "min-h-screen w-full bg-surface p-4 text-primary sm:p-6"
+          : "flex min-h-32 items-center justify-center bg-transparent p-4 text-primary"
+      }
+    >
+      <section
+        className={
+          expanded
+            ? "mx-auto w-full max-w-2xl"
+            : "w-full max-w-2xl rounded-lg border border-default bg-surface p-4 shadow-sm sm:p-5"
+        }
+      >
+        <header className="mb-4 flex flex-col gap-2">
+          <div className="flex flex-wrap items-center gap-2">
+            {badge}
+            <h1 className="heading-lg text-primary">{title}</h1>
+          </div>
+          {description ? (
+            <p className="text-sm leading-relaxed text-secondary">
+              {description}
+            </p>
+          ) : null}
+        </header>
+        {children}
+      </section>
+    </main>
+  );
+}
+
+function BasicsEmptyState({
+  title,
+  description,
+  tone,
+  loading = false,
+}: {
+  title: ReactNode;
+  description?: ReactNode;
+  tone: StatusTone;
+  loading?: boolean;
+}) {
+  return (
+    <div className="flex min-h-32 items-center justify-center p-4 text-primary">
+      <Alert
+        color={tone}
+        variant="soft"
+        title={
+          <span className="inline-flex items-center gap-2">
+            {loading ? <LoadingIndicator size={16} /> : null}
+            {title}
+          </span>
+        }
+        description={description}
+        className="w-full max-w-lg"
+      />
+    </div>
+  );
+}
+
+export function StatusAlert({
+  tone,
+  title,
+  description,
+  className = "mb-3",
+}: {
+  tone: StatusTone;
+  title: ReactNode;
+  description?: ReactNode;
+  className?: string;
+}) {
+  return (
+    <Alert
+      color={tone}
+      variant="soft"
+      title={title}
+      description={description}
+      className={className}
+    />
+  );
+}
+
+export function CodeWalkthrough({
+  steps,
+  title = "See the code and explanation",
+}: {
+  steps?: Step[];
+  title?: string;
+}) {
+  if (!steps?.length) {
+    return null;
+  }
+
+  return (
+    <details className="mt-5 border-t border-subtle pt-4">
+      <summary className="cursor-pointer text-sm font-medium text-secondary hover:text-primary">
+        {title}
+      </summary>
+      <ol className="mt-4 space-y-4">
+        {steps.map((step) => (
+          <li key={step.id} className="space-y-2">
+            <div className="flex items-start gap-2">
+              <Badge color="secondary" variant="soft" size="sm">
+                {step.id}
+              </Badge>
+              <div className="min-w-0 flex-1">
+                <h2 className="text-sm font-semibold text-primary">
+                  {step.title}
+                </h2>
+                <p className="text-sm leading-relaxed text-secondary">
+                  {step.summary}
+                </p>
+              </div>
+            </div>
+            {step.code ? (
+              <CodeBlock className="text-xs" language="tsx">
+                {step.code}
+              </CodeBlock>
+            ) : null}
+          </li>
+        ))}
+      </ol>
+      <div className="mt-4 flex flex-wrap gap-x-4 gap-y-2 text-xs">
+        <TextLink
+          href="https://developers.openai.com/apps-sdk/build/chatgpt-ui"
+          forceExternal
+        >
+          Build ChatGPT UI
+        </TextLink>
+        <TextLink href="https://developers.openai.com/apps-sdk/reference" forceExternal>
+          Apps SDK reference
+        </TextLink>
+        <TextLink
+          href="https://openai.github.io/apps-sdk-ui/?path=/docs/overview-introduction--docs"
+          forceExternal
+        >
+          Apps SDK UI
+        </TextLink>
+      </div>
+    </details>
+  );
+}
+
+export function KeyValueGrid({
+  rows,
+  className = "mb-4",
+}: {
+  rows: Array<{
+    label: ReactNode;
+    value: ReactNode;
+    badge?: ReactNode;
+  }>;
+  className?: string;
+}) {
+  return (
+    <dl
+      className={`grid grid-cols-[minmax(7rem,auto)_1fr] gap-x-3 gap-y-2 text-sm ${className}`}
+    >
+      {rows.map((row, index) => (
+        <div key={index} className="contents">
+          <dt className="min-w-0 font-mono text-xs text-secondary">
+            {row.label}
+          </dt>
+          <dd className="min-w-0 break-words font-mono text-sm text-primary">
+            <span className="inline-flex min-w-0 flex-wrap items-center gap-2">
+              {row.value}
+              {row.badge}
+            </span>
+          </dd>
+        </div>
+      ))}
+    </dl>
+  );
+}

--- a/src/mcp-app-basics/openai-helpers.ts
+++ b/src/mcp-app-basics/openai-helpers.ts
@@ -1,0 +1,89 @@
+import type { App as McpApp } from "@modelcontextprotocol/ext-apps";
+
+type DisplayMode = "inline" | "fullscreen" | "pip";
+
+export type ToolResultLike = {
+  content?: Array<{ type: string; text?: string }>;
+  structuredContent?: unknown;
+  isError?: boolean;
+  [key: string]: unknown;
+};
+
+type OpenAiBridge = {
+  callTool?: (
+    name: string,
+    args: Record<string, unknown>
+  ) => Promise<ToolResultLike>;
+  sendFollowUpMessage?: (args: {
+    prompt: string;
+    scrollToBottom?: boolean;
+  }) => Promise<void>;
+  openExternal?: (args: { href: string; redirectUrl?: string | false }) => void | Promise<void>;
+  requestDisplayMode?: (args: { mode: DisplayMode }) => Promise<{ mode: DisplayMode }>;
+};
+
+function getOpenAiBridge(): OpenAiBridge | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  return (window.openai as unknown as OpenAiBridge | undefined) ?? null;
+}
+
+export async function sendFollowUpMessage(
+  app: McpApp,
+  prompt: string
+): Promise<{ isError?: boolean }> {
+  const bridge = getOpenAiBridge();
+
+  if (bridge?.sendFollowUpMessage) {
+    await bridge.sendFollowUpMessage({ prompt, scrollToBottom: true });
+    return {};
+  }
+
+  return app.sendMessage({
+    role: "user",
+    content: [{ type: "text", text: prompt }],
+  });
+}
+
+export async function callTool(
+  app: McpApp,
+  name: string,
+  args: Record<string, unknown>
+): Promise<ToolResultLike> {
+  const bridge = getOpenAiBridge();
+
+  if (bridge?.callTool) {
+    return bridge.callTool(name, args);
+  }
+
+  return app.callServerTool({ name, arguments: args });
+}
+
+export async function openExternal(
+  app: McpApp,
+  href: string
+): Promise<{ isError?: boolean }> {
+  const bridge = getOpenAiBridge();
+
+  if (bridge?.openExternal) {
+    await bridge.openExternal({ href });
+    return {};
+  }
+
+  return app.openLink({ url: href });
+}
+
+export async function requestDisplayMode(
+  app: McpApp,
+  mode: DisplayMode
+): Promise<{ mode: DisplayMode }> {
+  const bridge = getOpenAiBridge();
+
+  if (bridge?.requestDisplayMode) {
+    return bridge.requestDisplayMode({ mode });
+  }
+
+  return app.requestDisplayMode({ mode });
+}

--- a/src/mcp-app-basics/types.ts
+++ b/src/mcp-app-basics/types.ts
@@ -1,0 +1,11 @@
+export interface Step {
+  id: number;
+  title: string;
+  summary: string;
+  code?: string;
+}
+
+export interface DemoData {
+  toolName: string;
+  steps: Step[];
+}

--- a/src/open-link/App.tsx
+++ b/src/open-link/App.tsx
@@ -1,19 +1,12 @@
 import { useApp } from "@modelcontextprotocol/ext-apps/react";
 import type { App as McpApp } from "@modelcontextprotocol/ext-apps";
 import { useState, useRef } from "react";
-import { HighlightedCode } from "../highlight-code";
-
-interface Step {
-  id: number;
-  title: string;
-  summary: string;
-  code?: string;
-}
-
-interface DemoData {
-  toolName: string;
-  steps: Step[];
-}
+import { Button } from "@openai/apps-sdk-ui/components/Button";
+import { Input } from "@openai/apps-sdk-ui/components/Input";
+import { ExternalLink } from "@openai/apps-sdk-ui/components/Icon";
+import { BasicsShell, CodeWalkthrough, StatusAlert } from "../mcp-app-basics/components";
+import { openExternal } from "../mcp-app-basics/openai-helpers";
+import type { DemoData } from "../mcp-app-basics/types";
 
 type Status = "idle" | "success" | "denied" | "error";
 
@@ -43,26 +36,16 @@ export default function App() {
   });
 
   if (error) {
-    return (
-      <div className="flex items-center justify-center min-h-32 p-4">
-        <p className="text-red-600 text-sm">Connection failed: {error.message}</p>
-      </div>
-    );
+    return <BasicsShell title="Open Link" error={error} isConnected={false} />;
   }
 
   if (!app) {
-    return (
-      <div className="flex items-center justify-center min-h-32 p-4">
-        <p className="text-gray-500 text-sm">Connecting...</p>
-      </div>
-    );
+    return <BasicsShell title="Open Link" isConnected={false} />;
   }
 
   if (!ready) {
     return (
-      <div className="flex items-center justify-center min-h-32 p-4">
-        <p className="text-gray-500 text-sm">Waiting for tool result...</p>
-      </div>
+      <BasicsShell title="Open Link" isConnected={true} isReady={false} />
     );
   }
 
@@ -71,7 +54,7 @@ export default function App() {
     if (timerRef.current) clearTimeout(timerRef.current);
 
     try {
-      const result = await app.openLink({ url });
+      const result = await openExternal(app, url);
       if (result.isError) {
         setStatus("denied");
       } else {
@@ -85,109 +68,71 @@ export default function App() {
   };
 
   return (
-    <div className="flex items-center justify-center p-4">
-      <div className="bg-white rounded-2xl shadow-lg border border-gray-200 p-6 max-w-xl w-full">
-        <h1 className="text-2xl font-bold text-gray-900 mb-2">Open Link</h1>
-        <p className="text-gray-600 mb-4">
-          Request the host to open a URL. The host may deny the request based on its security policy.
-        </p>
-
-        <div className="flex flex-wrap gap-2 mb-4">
-          {PREDEFINED_LINKS.map((link) => (
-            <button
-              key={link.url}
-              onClick={() => handleOpenLink(link.url)}
-              className="px-3 py-1.5 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700"
-            >
-              {link.label}
-            </button>
-          ))}
-        </div>
-
-        <div className="flex gap-2 mb-3">
-          <input
-            type="text"
-            value={customUrl}
-            onChange={(e) => setCustomUrl(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" && customUrl.trim()) handleOpenLink(customUrl.trim());
-            }}
-            placeholder="https://..."
-            className="flex-1 px-3 py-2 border border-gray-300 rounded-lg text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
-          />
-          <button
-            onClick={() => {
-              if (customUrl.trim()) handleOpenLink(customUrl.trim());
-            }}
-            disabled={!customUrl.trim()}
-            className="px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+    <BasicsShell
+      title="Open Link"
+      description="Ask the host to open a vetted external URL. The widget requests navigation, and the host decides whether to allow it."
+      isConnected={true}
+    >
+      <div className="mb-4 flex flex-wrap gap-2">
+        {PREDEFINED_LINKS.map((link) => (
+          <Button
+            key={link.url}
+            color="secondary"
+            variant="outline"
+            onClick={() => void handleOpenLink(link.url)}
           >
-            Open
-          </button>
-        </div>
-
-        {status === "success" && (
-          <p className="text-green-600 text-xs mb-2">
-            Opened: {lastUrl}
-          </p>
-        )}
-        {status === "denied" && (
-          <p className="text-amber-600 text-xs mb-2">
-            Denied by host: {lastUrl}
-          </p>
-        )}
-        {status === "error" && (
-          <p className="text-red-600 text-xs mb-2">
-            Error opening: {lastUrl}
-          </p>
-        )}
-
-        <div className="mt-4 p-3 bg-gray-50 rounded-lg text-xs text-gray-500 space-y-1">
-          <p><strong className="text-gray-700">How it works:</strong> All link requests go through the host — the app cannot open links directly.</p>
-          <p>The host decides whether to allow or deny each URL based on its security policy.</p>
-        </div>
-
-        {data && (
-          <details className="mt-4 border-t border-gray-100 pt-3">
-            <summary className="text-sm text-gray-500 cursor-pointer hover:text-gray-700">
-              See the code and explanation...
-            </summary>
-            <ol className="mt-3 space-y-4 text-sm text-gray-500">
-              {data.steps.map((step) => (
-                <li key={step.id}>
-                  <span className="font-medium text-gray-700">
-                    {step.id}. {step.title}
-                  </span>
-                  <span className="text-gray-400"> — {step.summary}</span>
-                  {step.code && (
-                    <pre className="mt-1.5 px-3 py-2.5 bg-gray-900 text-gray-300 text-xs leading-relaxed rounded-lg overflow-x-auto whitespace-pre">
-                      <code><HighlightedCode code={step.code} /></code>
-                    </pre>
-                  )}
-                </li>
-              ))}
-            </ol>
-            <div className="mt-3 text-xs text-gray-400 space-y-1">
-              <a
-                href="https://modelcontextprotocol.io/docs/extensions/apps"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="block hover:text-blue-500 underline"
-              >
-                MCP Apps docs
-              </a>
-              <a
-                href="https://modelcontextprotocol.github.io/ext-apps/api/"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="block hover:text-blue-500 underline"
-              >
-                API reference
-              </a>
-            </div>
-          </details>
-        )}
+            <ExternalLink />
+            {link.label}
+          </Button>
+        ))}
       </div>
-    </div>
+
+      <div className="mb-3 flex flex-col gap-2 sm:flex-row">
+        <Input
+          type="text"
+          value={customUrl}
+          onChange={(e) => setCustomUrl(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && customUrl.trim()) {
+              void handleOpenLink(customUrl.trim());
+            }
+          }}
+          placeholder="https://..."
+          className="min-w-0 flex-1"
+        />
+        <Button
+          color="primary"
+          onClick={() => {
+            if (customUrl.trim()) {
+              void handleOpenLink(customUrl.trim());
+            }
+          }}
+          disabled={!customUrl.trim()}
+          className="sm:w-fit"
+        >
+          <ExternalLink />
+          Open
+        </Button>
+      </div>
+
+      {status === "success" ? (
+        <StatusAlert tone="success" title="Opened" description={lastUrl} />
+      ) : null}
+      {status === "denied" ? (
+        <StatusAlert tone="warning" title="Denied by host" description={lastUrl} />
+      ) : null}
+      {status === "error" ? (
+        <StatusAlert tone="danger" title="Open failed" description={lastUrl} />
+      ) : null}
+
+      <StatusAlert
+        tone="info"
+        title="Host-mediated navigation"
+        description="The app cannot open links directly. All requests go through the host security policy."
+        className="mt-4"
+      />
+
+      <CodeWalkthrough steps={data?.steps} />
+    </BasicsShell>
   );
 }

--- a/src/request-display-mode/App.tsx
+++ b/src/request-display-mode/App.tsx
@@ -1,19 +1,13 @@
 import { useApp } from "@modelcontextprotocol/ext-apps/react";
 import type { App as McpApp } from "@modelcontextprotocol/ext-apps";
 import { useState } from "react";
-import { HighlightedCode } from "../highlight-code";
-
-interface Step {
-  id: number;
-  title: string;
-  summary: string;
-  code?: string;
-}
-
-interface DemoData {
-  toolName: string;
-  steps: Step[];
-}
+import { Badge } from "@openai/apps-sdk-ui/components/Badge";
+import { Button } from "@openai/apps-sdk-ui/components/Button";
+import { SegmentedControl } from "@openai/apps-sdk-ui/components/SegmentedControl";
+import { Expand } from "@openai/apps-sdk-ui/components/Icon";
+import { BasicsShell, CodeWalkthrough, KeyValueGrid, StatusAlert } from "../mcp-app-basics/components";
+import { requestDisplayMode } from "../mcp-app-basics/openai-helpers";
+import type { DemoData } from "../mcp-app-basics/types";
 
 type DisplayMode = "inline" | "fullscreen" | "pip";
 
@@ -53,26 +47,16 @@ export default function App() {
   });
 
   if (error) {
-    return (
-      <div className="flex items-center justify-center min-h-32 p-4">
-        <p className="text-red-600 text-sm">Connection failed: {error.message}</p>
-      </div>
-    );
+    return <BasicsShell title="Request Display Mode" error={error} isConnected={false} />;
   }
 
   if (!app) {
-    return (
-      <div className="flex items-center justify-center min-h-32 p-4">
-        <p className="text-gray-500 text-sm">Connecting...</p>
-      </div>
-    );
+    return <BasicsShell title="Request Display Mode" isConnected={false} />;
   }
 
   if (!ready) {
     return (
-      <div className="flex items-center justify-center min-h-32 p-4">
-        <p className="text-gray-500 text-sm">Waiting for tool result...</p>
-      </div>
+      <BasicsShell title="Request Display Mode" isConnected={true} isReady={false} />
     );
   }
 
@@ -81,7 +65,7 @@ export default function App() {
     setModeResult(null);
 
     try {
-      const result = await app.requestDisplayMode({ mode });
+      const result = await requestDisplayMode(app, mode);
       setModeResult({ requested: mode, granted: result.mode as DisplayMode });
       setCurrentMode(result.mode);
     } catch (err) {
@@ -92,104 +76,89 @@ export default function App() {
   const allModes: DisplayMode[] = ["inline", "fullscreen", "pip"];
 
   const isExpanded = currentMode === "fullscreen" || currentMode === "pip";
+  const selectedMode = allModes.includes(currentMode as DisplayMode)
+    ? (currentMode as DisplayMode)
+    : "inline";
 
   return (
-    <div className={isExpanded ? "min-h-screen w-full p-6 bg-white dark:bg-gray-900" : "flex items-center justify-center p-4"}>
-      <div className={isExpanded ? "max-w-xl w-full mx-auto" : "bg-white dark:bg-gray-900 rounded-2xl shadow-lg border border-gray-200 dark:border-gray-700 p-6 max-w-xl w-full"}>
-        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-2">Request Display Mode</h1>
-        <p className="text-gray-600 dark:text-gray-400 mb-4">
-          Request the host to change the widget's display mode. Must be called from a user action (button click).
-        </p>
-
-        <div className="mb-4 px-4 py-3 bg-blue-50 dark:bg-blue-900/30 border border-blue-200 dark:border-blue-800 rounded-lg text-sm">
-          <p className="text-blue-800 dark:text-blue-300">
-            <span className="font-medium">Current mode:</span> {currentMode ?? "unknown"}
-          </p>
-          <p className="text-blue-700 dark:text-blue-400 mt-1">
-            <span className="font-medium">Available modes:</span>{" "}
-            {availableModes.length > 0 ? availableModes.join(", ") : "none reported"}
-          </p>
-        </div>
-
-        <div className="flex gap-2 mb-3">
-          {allModes.map((mode) => {
-            const isAvailable = availableModes.length === 0 || availableModes.includes(mode);
-            const isCurrent = currentMode === mode;
-            return (
-              <button
-                key={mode}
-                onClick={() => handleRequestMode(mode)}
-                disabled={!isAvailable}
-                className={`px-4 py-2 text-sm font-medium rounded-lg border ${
-                  isCurrent
-                    ? "bg-blue-600 text-white border-blue-600"
-                    : isAvailable
-                      ? "bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:border-gray-400 dark:hover:border-gray-500"
-                      : "bg-gray-100 dark:bg-gray-800 text-gray-400 dark:text-gray-600 border-gray-200 dark:border-gray-700 cursor-not-allowed"
-                }`}
-              >
-                {mode}
-              </button>
-            );
-          })}
-        </div>
-
-        {modeResult && (
-          <p className={`text-xs mb-2 ${
-            modeResult.requested === modeResult.granted ? "text-green-600" : "text-amber-600"
-          }`}>
-            Requested: {modeResult.requested} → Granted: {modeResult.granted}
-          </p>
-        )}
-        {errorMsg && (
-          <p className="text-red-600 text-xs mb-2">{errorMsg}</p>
-        )}
-
-        <p className="text-xs text-amber-600 mb-3">
-          Note: requestDisplayMode() must be called from a user-initiated action (e.g. button click). It will fail if called programmatically.
-        </p>
-
-        {data && (
-          <details className="mt-4 border-t border-gray-100 dark:border-gray-700 pt-3">
-            <summary className="text-sm text-gray-500 dark:text-gray-400 cursor-pointer hover:text-gray-700 dark:hover:text-gray-300">
-              See the code and explanation...
-            </summary>
-            <ol className="mt-3 space-y-4 text-sm text-gray-500 dark:text-gray-400">
-              {data.steps.map((step) => (
-                <li key={step.id}>
-                  <span className="font-medium text-gray-700 dark:text-gray-300">
-                    {step.id}. {step.title}
-                  </span>
-                  <span className="text-gray-400 dark:text-gray-500"> — {step.summary}</span>
-                  {step.code && (
-                    <pre className="mt-1.5 px-3 py-2.5 bg-gray-900 text-gray-300 text-xs leading-relaxed rounded-lg overflow-x-auto whitespace-pre">
-                      <code><HighlightedCode code={step.code} /></code>
-                    </pre>
-                  )}
-                </li>
-              ))}
-            </ol>
-            <div className="mt-3 text-xs text-gray-400 dark:text-gray-500 space-y-1">
-              <a
-                href="https://modelcontextprotocol.io/docs/extensions/apps"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="block hover:text-blue-500 underline"
-              >
-                MCP Apps docs
-              </a>
-              <a
-                href="https://modelcontextprotocol.github.io/ext-apps/api/"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="block hover:text-blue-500 underline"
-              >
-                API reference
-              </a>
-            </div>
-          </details>
-        )}
+    <BasicsShell
+      title="Request Display Mode"
+      description="Request inline, fullscreen, or picture-in-picture display from a user action. The host may grant a different mode."
+      isConnected={true}
+      expanded={isExpanded}
+      badge={<Badge color="info">{currentMode ?? "unknown"}</Badge>}
+    >
+      <div className="mb-4 rounded-lg border border-subtle bg-surface-secondary p-3">
+        <KeyValueGrid
+          className="mb-0"
+          rows={[
+            { label: "current", value: currentMode ?? "unknown" },
+            {
+              label: "available",
+              value:
+                availableModes.length > 0
+                  ? availableModes.join(", ")
+                  : "none reported",
+            },
+          ]}
+        />
       </div>
-    </div>
+
+      <div className="mb-3 flex flex-col gap-3 sm:flex-row sm:items-center">
+        <SegmentedControl<DisplayMode>
+          value={selectedMode}
+          onChange={(mode) => void handleRequestMode(mode)}
+          aria-label="Display mode"
+          size="md"
+        >
+          {allModes.map((mode) => (
+            <SegmentedControl.Option
+              key={mode}
+              value={mode}
+              disabled={availableModes.length > 0 && !availableModes.includes(mode)}
+            >
+              {mode}
+            </SegmentedControl.Option>
+          ))}
+        </SegmentedControl>
+        <Button
+          color="secondary"
+          variant="outline"
+          onClick={() => void handleRequestMode("fullscreen")}
+          disabled={
+            availableModes.length > 0 && !availableModes.includes("fullscreen")
+          }
+          className="w-fit"
+        >
+          <Expand />
+          Fullscreen
+        </Button>
+      </div>
+
+      {modeResult ? (
+        <StatusAlert
+          tone={
+            modeResult.requested === modeResult.granted ? "success" : "warning"
+          }
+          title="Display mode response"
+          description={`Requested ${modeResult.requested}; granted ${modeResult.granted}.`}
+        />
+      ) : null}
+      {errorMsg ? (
+        <StatusAlert
+          tone="danger"
+          title="Display mode request failed"
+          description={errorMsg}
+        />
+      ) : null}
+
+      <StatusAlert
+        tone="caution"
+        title="User action required"
+        description="requestDisplayMode must be called from a user-initiated event such as a button click."
+      />
+
+      <CodeWalkthrough steps={data?.steps} />
+    </BasicsShell>
   );
 }

--- a/src/send-message/App.tsx
+++ b/src/send-message/App.tsx
@@ -1,19 +1,12 @@
 import { useApp } from "@modelcontextprotocol/ext-apps/react";
 import type { App as McpApp } from "@modelcontextprotocol/ext-apps";
 import { useState, useRef } from "react";
-import { HighlightedCode } from "../highlight-code";
-
-interface Step {
-  id: number;
-  title: string;
-  summary: string;
-  code?: string;
-}
-
-interface DemoData {
-  toolName: string;
-  steps: Step[];
-}
+import { Button } from "@openai/apps-sdk-ui/components/Button";
+import { Input } from "@openai/apps-sdk-ui/components/Input";
+import { ChatCompose } from "@openai/apps-sdk-ui/components/Icon";
+import { BasicsShell, CodeWalkthrough, StatusAlert } from "../mcp-app-basics/components";
+import { sendFollowUpMessage } from "../mcp-app-basics/openai-helpers";
+import type { DemoData } from "../mcp-app-basics/types";
 
 type Status = "idle" | "sending" | "sent" | "error";
 
@@ -36,26 +29,16 @@ export default function App() {
   });
 
   if (error) {
-    return (
-      <div className="flex items-center justify-center min-h-32 p-4">
-        <p className="text-red-600 text-sm">Connection failed: {error.message}</p>
-      </div>
-    );
+    return <BasicsShell title="Send Message" error={error} isConnected={false} />;
   }
 
   if (!app) {
-    return (
-      <div className="flex items-center justify-center min-h-32 p-4">
-        <p className="text-gray-500 text-sm">Connecting...</p>
-      </div>
-    );
+    return <BasicsShell title="Send Message" isConnected={false} />;
   }
 
   if (!ready) {
     return (
-      <div className="flex items-center justify-center min-h-32 p-4">
-        <p className="text-gray-500 text-sm">Waiting for tool result...</p>
-      </div>
+      <BasicsShell title="Send Message" isConnected={true} isReady={false} />
     );
   }
 
@@ -65,10 +48,10 @@ export default function App() {
     setStatus("sending");
 
     try {
-      const result = await app.sendMessage({
-        role: "user",
-        content: [{ type: "text", text: `[Sent from the Send Message demo widget]: ${text.trim()}` }],
-      });
+      const result = await sendFollowUpMessage(
+        app,
+        `[Sent from the Send Message demo widget]: ${text.trim()}`
+      );
 
       if (result.isError) {
         setStatus("error");
@@ -84,82 +67,53 @@ export default function App() {
   };
 
   return (
-    <div className="flex items-center justify-center p-4">
-      <div className="bg-white rounded-2xl shadow-lg border border-gray-200 p-6 max-w-xl w-full">
-        <h1 className="text-2xl font-bold text-gray-900 mb-2">Send Message</h1>
-        <p className="text-gray-600 mb-4">
-          Type a message and send it into the conversation. The model will respond.
-        </p>
-
-        <div className="flex gap-2 mb-2">
-          <input
-            type="text"
-            value={text}
-            onChange={(e) => setText(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") handleSend();
-            }}
-            placeholder="Type a message..."
-            disabled={status === "sending"}
-            className="flex-1 px-3 py-2 border border-gray-300 rounded-lg text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
-          />
-          <button
-            onClick={handleSend}
-            disabled={status === "sending" || !text.trim()}
-            className="px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            {status === "sending" ? "Sending..." : "Send"}
-          </button>
-        </div>
-
-        {status === "sent" && (
-          <p className="text-green-600 text-xs mb-2">Message sent! The model will respond.</p>
-        )}
-        {status === "error" && (
-          <p className="text-red-600 text-xs mb-2">Failed to send message.</p>
-        )}
-
-        {data && (
-          <details className="mt-4 border-t border-gray-100 pt-3">
-            <summary className="text-sm text-gray-500 cursor-pointer hover:text-gray-700">
-              See the code and explanation...
-            </summary>
-            <ol className="mt-3 space-y-4 text-sm text-gray-500">
-              {data.steps.map((step) => (
-                <li key={step.id}>
-                  <span className="font-medium text-gray-700">
-                    {step.id}. {step.title}
-                  </span>
-                  <span className="text-gray-400"> — {step.summary}</span>
-                  {step.code && (
-                    <pre className="mt-1.5 px-3 py-2.5 bg-gray-900 text-gray-300 text-xs leading-relaxed rounded-lg overflow-x-auto whitespace-pre">
-                      <code><HighlightedCode code={step.code} /></code>
-                    </pre>
-                  )}
-                </li>
-              ))}
-            </ol>
-            <div className="mt-3 text-xs text-gray-400 space-y-1">
-              <a
-                href="https://modelcontextprotocol.io/docs/extensions/apps"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="block hover:text-blue-500 underline"
-              >
-                MCP Apps docs
-              </a>
-              <a
-                href="https://modelcontextprotocol.github.io/ext-apps/api/"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="block hover:text-blue-500 underline"
-              >
-                API reference
-              </a>
-            </div>
-          </details>
-        )}
+    <BasicsShell
+      title="Send Message"
+      description="Type a message and send it into the conversation. ChatGPT will respond from the component-authored follow-up."
+      isConnected={true}
+    >
+      <div className="mb-3 flex flex-col gap-2 sm:flex-row">
+        <Input
+          type="text"
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              void handleSend();
+            }
+          }}
+          placeholder="Type a message..."
+          disabled={status === "sending"}
+          className="min-w-0 flex-1"
+        />
+        <Button
+          color="primary"
+          onClick={() => void handleSend()}
+          disabled={status === "sending" || !text.trim()}
+          loading={status === "sending"}
+          className="sm:w-fit"
+        >
+          <ChatCompose />
+          {status === "sending" ? "Sending" : "Send"}
+        </Button>
       </div>
-    </div>
+
+      {status === "sent" ? (
+        <StatusAlert
+          tone="success"
+          title="Message sent"
+          description="The follow-up was handed to ChatGPT."
+        />
+      ) : null}
+      {status === "error" ? (
+        <StatusAlert
+          tone="danger"
+          title="Failed to send"
+          description="The host rejected the follow-up or the bridge call failed."
+        />
+      ) : null}
+
+      <CodeWalkthrough steps={data?.steps} />
+    </BasicsShell>
   );
 }

--- a/src/show-tool-result/App.tsx
+++ b/src/show-tool-result/App.tsx
@@ -1,14 +1,9 @@
 import { useApp } from "@modelcontextprotocol/ext-apps/react";
 import type { App as McpApp } from "@modelcontextprotocol/ext-apps";
 import { useState } from "react";
-import { HighlightedCode } from "../highlight-code";
-
-interface Step {
-  id: number;
-  title: string;
-  summary: string;
-  code?: string;
-}
+import { Badge } from "@openai/apps-sdk-ui/components/Badge";
+import { CodeWalkthrough, BasicsShell, KeyValueGrid } from "../mcp-app-basics/components";
+import type { Step } from "../mcp-app-basics/types";
 
 interface DemoData {
   greeting: string;
@@ -33,75 +28,36 @@ export default function App() {
   });
 
   if (error) {
-    return (
-      <div className="flex items-center justify-center min-h-32 p-4">
-        <p className="text-red-600 text-sm">Connection failed: {error.message}</p>
-      </div>
-    );
+    return <BasicsShell title="Show Tool Result" error={error} isConnected={false}> </BasicsShell>;
   }
 
   if (!app) {
-    return (
-      <div className="flex items-center justify-center min-h-32 p-4">
-        <p className="text-gray-500 text-sm">Connecting...</p>
-      </div>
-    );
+    return <BasicsShell title="Show Tool Result" isConnected={false}> </BasicsShell>;
   }
 
   if (!data) {
     return (
-      <div className="flex items-center justify-center min-h-32 p-4">
-        <p className="text-gray-500 text-sm">Waiting for tool result...</p>
-      </div>
+      <BasicsShell title="Show Tool Result" isConnected={true} isReady={false}>
+        {" "}
+      </BasicsShell>
     );
   }
 
   return (
-    <div className="flex items-center justify-center p-4">
-      <div className="bg-white rounded-2xl shadow-lg border border-gray-200 p-6 max-w-xl w-full">
-        <h1 className="text-2xl font-bold text-gray-900 mb-2">{data.greeting}</h1>
-        <p className="text-gray-600 mb-4">{data.message}</p>
-        <p className="text-xs text-gray-400">{data.timestamp}</p>
-
-        <details className="mt-4 border-t border-gray-100 pt-3">
-          <summary className="text-sm text-gray-500 cursor-pointer hover:text-gray-700">
-            See the code and explanation...
-          </summary>
-          <ol className="mt-3 space-y-4 text-sm text-gray-500">
-            {data.steps.map((step) => (
-              <li key={step.id}>
-                <span className="font-medium text-gray-700">
-                  {step.id}. {step.title}
-                </span>
-                <span className="text-gray-400"> — {step.summary}</span>
-                {step.code && (
-                  <pre className="mt-1.5 px-3 py-2.5 bg-gray-900 text-gray-300 text-xs leading-relaxed rounded-lg overflow-x-auto whitespace-pre">
-                    <code><HighlightedCode code={step.code} /></code>
-                  </pre>
-                )}
-              </li>
-            ))}
-          </ol>
-          <div className="mt-3 text-xs text-gray-400 space-y-1">
-            <a
-              href="https://modelcontextprotocol.io/docs/extensions/apps"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="block hover:text-blue-500 underline"
-            >
-              MCP Apps docs
-            </a>
-            <a
-              href="https://modelcontextprotocol.github.io/ext-apps/api/"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="block hover:text-blue-500 underline"
-            >
-              API reference
-            </a>
-          </div>
-        </details>
-      </div>
-    </div>
+    <BasicsShell
+      title={data.greeting}
+      description={data.message}
+      isConnected={true}
+      badge={<Badge color="info">structuredContent</Badge>}
+    >
+      <KeyValueGrid
+        rows={[
+          { label: "tool", value: data.toolName },
+          { label: "input", value: JSON.stringify(data.inputReceived) },
+          { label: "timestamp", value: data.timestamp },
+        ]}
+      />
+      <CodeWalkthrough steps={data.steps} />
+    </BasicsShell>
   );
 }

--- a/src/streaming-tool-input/App.tsx
+++ b/src/streaming-tool-input/App.tsx
@@ -1,19 +1,10 @@
 import { useApp } from "@modelcontextprotocol/ext-apps/react";
 import type { App as McpApp } from "@modelcontextprotocol/ext-apps";
 import { useState } from "react";
-import { HighlightedCode } from "../highlight-code";
-
-interface Step {
-  id: number;
-  title: string;
-  summary: string;
-  code?: string;
-}
-
-interface DemoData {
-  toolName: string;
-  steps: Step[];
-}
+import { Badge } from "@openai/apps-sdk-ui/components/Badge";
+import { CodeBlock } from "@openai/apps-sdk-ui/components/CodeBlock";
+import { BasicsShell, CodeWalkthrough, StatusAlert } from "../mcp-app-basics/components";
+import type { DemoData } from "../mcp-app-basics/types";
 
 interface StoryInput {
   title?: string;
@@ -30,14 +21,14 @@ function formatStory(story: StoryInput, { fadeTrailing }: { fadeTrailing: boolea
   return (
     <>
       {story.paragraphs && story.paragraphs.length > 0 && (
-        <div className="space-y-3 mt-3 border-t border-gray-200 pt-3">
+        <div className="mt-3 space-y-3 border-t border-subtle pt-3">
           {story.paragraphs.map((paragraph, i) => (
             <p
               key={i}
               className={`text-sm leading-relaxed ${
                 fadeTrailing && i === story.paragraphs!.length - 1
-                  ? "text-gray-400"
-                  : "text-gray-700"
+                  ? "text-tertiary"
+                  : "text-primary"
               }`}
             >
               {paragraph}
@@ -46,8 +37,8 @@ function formatStory(story: StoryInput, { fadeTrailing }: { fadeTrailing: boolea
         </div>
       )}
       {story.moral !== undefined && (
-        <p className={`mt-3 pt-3 border-t border-gray-200 text-sm italic ${
-          fadeTrailing ? "text-gray-400" : "text-gray-600"
+        <p className={`mt-3 border-t border-subtle pt-3 text-sm italic ${
+          fadeTrailing ? "text-tertiary" : "text-secondary"
         }`}>
           Moral: {story.moral || "..."}
         </p>
@@ -80,116 +71,77 @@ export default function App() {
   });
 
   if (error) {
-    return (
-      <div className="flex items-center justify-center min-h-32 p-4">
-        <p className="text-red-600 text-sm">Connection failed: {error.message}</p>
-      </div>
-    );
+    return <BasicsShell title="Streaming Tool Input" error={error} isConnected={false} />;
   }
 
   if (!app) {
-    return (
-      <div className="flex items-center justify-center min-h-32 p-4">
-        <p className="text-gray-500 text-sm">Connecting...</p>
-      </div>
-    );
+    return <BasicsShell title="Streaming Tool Input" isConnected={false} />;
   }
-
-  const phaseColors: Record<Phase, string> = {
-    waiting: "bg-gray-100 border-gray-300 text-gray-700",
-    streaming: "bg-blue-50 border-blue-300 text-blue-700",
-    complete: "bg-green-50 border-green-300 text-green-700",
-  };
 
   const phaseLabels: Record<Phase, string> = {
     waiting: "Waiting for model to call tool...",
     streaming: "Streaming input...",
     complete: "Complete",
   };
+  const phaseTone: Record<Phase, "secondary" | "info" | "success"> = {
+    waiting: "secondary",
+    streaming: "info",
+    complete: "success",
+  };
 
   return (
-    <div className="flex items-center justify-center p-4">
-      <div className="bg-white rounded-2xl shadow-lg border border-gray-200 p-6 max-w-xl w-full">
-        <h1 className="text-2xl font-bold text-gray-900 mb-2">Streaming Tool Input</h1>
-        <p className="text-gray-600 mb-4">
-          Watch tool arguments stream in progressively as the model generates them.
-        </p>
+    <BasicsShell
+      title="Streaming Tool Input"
+      description="Watch tool arguments render progressively as the model generates them."
+      isConnected={true}
+      badge={<Badge color={phaseTone[phase]}>{phaseLabels[phase]}</Badge>}
+    >
+      {!story ? (
+        <StatusAlert
+          tone="info"
+          title="Waiting for streamed arguments"
+          description="Ask ChatGPT to show streaming tool input, and this widget will preview the story fields as they arrive."
+        />
+      ) : null}
 
-        {/* Phase indicator */}
-        <div className={`mb-4 px-4 py-2 border rounded-lg text-sm font-medium ${phaseColors[phase]}`}>
-          {phaseLabels[phase]}
+      {story ? (
+        <div
+          className={`mb-4 rounded-lg border p-4 ${
+            phase === "streaming"
+              ? "border-info bg-surface-secondary"
+              : "border-subtle bg-surface-secondary"
+          }`}
+        >
+          {story.title !== undefined ? (
+            <h2 className="heading-md mb-1 text-primary">{story.title || "..."}</h2>
+          ) : null}
+          {story.author !== undefined ? (
+            <p className="mb-1 text-sm text-secondary">
+              by {story.author || "..."}
+            </p>
+          ) : null}
+          {story.genre !== undefined ? (
+            <p className="text-xs italic text-tertiary">{story.genre || "..."}</p>
+          ) : null}
+          {story.setting !== undefined ? (
+            <p className="mb-3 text-xs text-secondary">
+              Setting: {story.setting || "..."}
+            </p>
+          ) : null}
+          {formatStory(story, { fadeTrailing: phase === "streaming" })}
         </div>
+      ) : null}
 
-        {/* Story preview card */}
-        {story && (
-          <div className={`mb-4 border rounded-xl p-5 ${
-            phase === "streaming" ? "border-blue-200 bg-blue-50/50" : "border-gray-200 bg-gray-50"
-          }`}>
-            {story.title !== undefined && (
-              <h2 className={`text-xl font-bold mb-1 ${phase === "streaming" ? "text-gray-700" : "text-gray-900"}`}>
-                {story.title || "..."}
-              </h2>
-            )}
-            {story.author !== undefined && (
-              <p className={`text-sm mb-1 ${phase === "streaming" ? "text-gray-500" : "text-gray-600"}`}>
-                by {story.author || "..."}
-              </p>
-            )}
-            {story.genre !== undefined && (
-              <p className={`text-xs italic ${phase === "streaming" ? "text-gray-400" : "text-gray-500"}`}>
-                {story.genre || "..."}
-              </p>
-            )}
-            {story.setting !== undefined && (
-              <p className={`text-xs mb-3 ${phase === "streaming" ? "text-gray-400" : "text-gray-500"}`}>
-                Setting: {story.setting || "..."}
-              </p>
-            )}
-            {formatStory(story, { fadeTrailing: phase === "streaming" })}
-          </div>
-        )}
+      {story ? (
+        <div className="mb-4 space-y-2">
+          <p className="text-xs font-medium uppercase text-secondary">
+            Current streamed input
+          </p>
+          <CodeBlock language="json">{JSON.stringify(story, null, 2)}</CodeBlock>
+        </div>
+      ) : null}
 
-        {data && (
-          <details className="mt-4 border-t border-gray-100 pt-3">
-            <summary className="text-sm text-gray-500 cursor-pointer hover:text-gray-700">
-              See the code and explanation...
-            </summary>
-            <ol className="mt-3 space-y-4 text-sm text-gray-500">
-              {data.steps.map((step) => (
-                <li key={step.id}>
-                  <span className="font-medium text-gray-700">
-                    {step.id}. {step.title}
-                  </span>
-                  <span className="text-gray-400"> — {step.summary}</span>
-                  {step.code && (
-                    <pre className="mt-1.5 px-3 py-2.5 bg-gray-900 text-gray-300 text-xs leading-relaxed rounded-lg overflow-x-auto whitespace-pre">
-                      <code><HighlightedCode code={step.code} /></code>
-                    </pre>
-                  )}
-                </li>
-              ))}
-            </ol>
-            <div className="mt-3 text-xs text-gray-400 space-y-1">
-              <a
-                href="https://modelcontextprotocol.io/docs/extensions/apps"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="block hover:text-blue-500 underline"
-              >
-                MCP Apps docs
-              </a>
-              <a
-                href="https://modelcontextprotocol.github.io/ext-apps/api/"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="block hover:text-blue-500 underline"
-              >
-                API reference
-              </a>
-            </div>
-          </details>
-        )}
-      </div>
-    </div>
+      <CodeWalkthrough steps={data?.steps} />
+    </BasicsShell>
   );
 }

--- a/src/update-model-context/App.tsx
+++ b/src/update-model-context/App.tsx
@@ -1,19 +1,12 @@
 import { useApp } from "@modelcontextprotocol/ext-apps/react";
 import type { App as McpApp } from "@modelcontextprotocol/ext-apps";
 import { useState } from "react";
-import { HighlightedCode } from "../highlight-code";
-
-interface Step {
-  id: number;
-  title: string;
-  summary: string;
-  code?: string;
-}
-
-interface DemoData {
-  toolName: string;
-  steps: Step[];
-}
+import { Button } from "@openai/apps-sdk-ui/components/Button";
+import { Textarea } from "@openai/apps-sdk-ui/components/Textarea";
+import { CodeBlock } from "@openai/apps-sdk-ui/components/CodeBlock";
+import { Brain } from "@openai/apps-sdk-ui/components/Icon";
+import { BasicsShell, CodeWalkthrough, StatusAlert } from "../mcp-app-basics/components";
+import type { DemoData } from "../mcp-app-basics/types";
 
 type Status = "idle" | "updating" | "updated" | "error";
 
@@ -36,26 +29,16 @@ export default function App() {
   });
 
   if (error) {
-    return (
-      <div className="flex items-center justify-center min-h-32 p-4">
-        <p className="text-red-600 text-sm">Connection failed: {error.message}</p>
-      </div>
-    );
+    return <BasicsShell title="Update Model Context" error={error} isConnected={false} />;
   }
 
   if (!app) {
-    return (
-      <div className="flex items-center justify-center min-h-32 p-4">
-        <p className="text-gray-500 text-sm">Connecting...</p>
-      </div>
-    );
+    return <BasicsShell title="Update Model Context" isConnected={false} />;
   }
 
   if (!ready) {
     return (
-      <div className="flex items-center justify-center min-h-32 p-4">
-        <p className="text-gray-500 text-sm">Waiting for tool result...</p>
-      </div>
+      <BasicsShell title="Update Model Context" isConnected={true} isReady={false} />
     );
   }
 
@@ -78,86 +61,59 @@ export default function App() {
   };
 
   return (
-    <div className="flex items-center justify-center p-4">
-      <div className="bg-white rounded-2xl shadow-lg border border-gray-200 p-6 max-w-xl w-full">
-        <h1 className="text-2xl font-bold text-gray-900 mb-2">Update Model Context</h1>
-        <p className="text-gray-600 mb-4">
-          Set context that the model will receive on its next turn. No immediate response.
-        </p>
-
-        <textarea
+    <BasicsShell
+      title="Update Model Context"
+      description="Set context that the model receives on its next turn. The update is quiet and does not trigger an immediate response."
+      isConnected={true}
+    >
+      <div className="space-y-3">
+        <Textarea
           value={text}
           onChange={(e) => setText(e.target.value)}
           placeholder="Enter context for the model..."
           disabled={status === "updating"}
           rows={3}
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 resize-none mb-2"
+          autoResize
         />
-        <button
-          onClick={handleSetContext}
+        <Button
+          color="primary"
+          onClick={() => void handleSetContext()}
           disabled={status === "updating" || !text.trim()}
-          className="px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+          loading={status === "updating"}
+          className="w-fit"
         >
-          {status === "updating" ? "Setting..." : "Set Context"}
-        </button>
-
-        {status === "updated" && (
-          <p className="text-green-600 text-xs mt-2">
-            Context set. It will be included in the model's next turn.
-          </p>
-        )}
-        {status === "error" && (
-          <p className="text-red-600 text-xs mt-2">Failed to update context.</p>
-        )}
-
-        {currentContext && (
-          <div className="mt-3 px-3 py-2 bg-gray-50 rounded-lg border border-gray-200">
-            <p className="text-xs text-gray-400 mb-1">Current context:</p>
-            <p className="text-sm text-gray-700 break-words">{currentContext}</p>
-          </div>
-        )}
-
-        {data && (
-          <details className="mt-4 border-t border-gray-100 pt-3">
-            <summary className="text-sm text-gray-500 cursor-pointer hover:text-gray-700">
-              See the code and explanation...
-            </summary>
-            <ol className="mt-3 space-y-4 text-sm text-gray-500">
-              {data.steps.map((step) => (
-                <li key={step.id}>
-                  <span className="font-medium text-gray-700">
-                    {step.id}. {step.title}
-                  </span>
-                  <span className="text-gray-400"> — {step.summary}</span>
-                  {step.code && (
-                    <pre className="mt-1.5 px-3 py-2.5 bg-gray-900 text-gray-300 text-xs leading-relaxed rounded-lg overflow-x-auto whitespace-pre">
-                      <code><HighlightedCode code={step.code} /></code>
-                    </pre>
-                  )}
-                </li>
-              ))}
-            </ol>
-            <div className="mt-3 text-xs text-gray-400 space-y-1">
-              <a
-                href="https://modelcontextprotocol.io/docs/extensions/apps"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="block hover:text-blue-500 underline"
-              >
-                MCP Apps docs
-              </a>
-              <a
-                href="https://modelcontextprotocol.github.io/ext-apps/api/"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="block hover:text-blue-500 underline"
-              >
-                API reference
-              </a>
-            </div>
-          </details>
-        )}
+          <Brain />
+          {status === "updating" ? "Setting" : "Set context"}
+        </Button>
       </div>
-    </div>
+
+      {status === "updated" ? (
+        <StatusAlert
+          tone="success"
+          title="Context set"
+          description="The latest context will be included in the model's next turn."
+          className="mt-3"
+        />
+      ) : null}
+      {status === "error" ? (
+        <StatusAlert
+          tone="danger"
+          title="Failed to update context"
+          description="The host rejected the context update or the bridge call failed."
+          className="mt-3"
+        />
+      ) : null}
+
+      {currentContext ? (
+        <div className="mt-4 space-y-2">
+          <p className="text-xs font-medium uppercase text-secondary">
+            Current context
+          </p>
+          <CodeBlock language="text">{currentContext}</CodeBlock>
+        </div>
+      ) : null}
+
+      <CodeWalkthrough steps={data?.steps} />
+    </BasicsShell>
   );
 }


### PR DESCRIPTION
Updated the MCP App Basics examples to use the Apps SDK UI library. Found here: https://openai.github.io/apps-sdk-ui/?path=/docs/overview-introduction--docs

Also updated the scripts to make sure that calling `pnpm start` in the mcp app basics server directory rebuilt all UI files and added a cache-busting hash to the URLs for them.

cc @cching-openai 